### PR TITLE
Don't escape the query string before calling encode.

### DIFF
--- a/search.go
+++ b/search.go
@@ -142,7 +142,6 @@ func (c *Client) Search(query string, t SearchType) (*SearchResult, error) {
 // If the client has a valid access token, then the results will only include
 // content playable in the user's country.
 func (c *Client) SearchOpt(query string, t SearchType, opt *Options) (*SearchResult, error) {
-	query = url.QueryEscape(query)
 	v := url.Values{}
 	v.Set("q", query)
 	v.Set("type", t.encode())

--- a/search_test.go
+++ b/search_test.go
@@ -66,6 +66,34 @@ func TestSearchTracks(t *testing.T) {
 	}
 }
 
+func TestSearchTrackWithFilter(t *testing.T) {
+	if os.Getenv("FULLTEST") == "" {
+		t.Skip()
+		return
+	}
+
+	result, err := Search("uptown artist:bruno mars", SearchTypeTrack)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if result.Albums != nil {
+		t.Error("Searched for tracks but got album results")
+	}
+	if result.Playlists != nil {
+		t.Error("Searched for tracks but got playlist results")
+	}
+	if result.Artists != nil {
+		t.Error("Searched for tracks but got artist results")
+	}
+	if result.Tracks == nil || len(result.Tracks.Tracks) == 0 {
+		t.Fatal("Didn't receive track results")
+	}
+	if name := result.Tracks.Tracks[0].Name; name != "Uptown Funk" {
+		t.Errorf("Got %s, wanted Uptown Funk\n", name)
+	}
+}
+
 func TestSearchPlaylistTrack(t *testing.T) {
 	client := testClientFile(http.StatusOK, "test_data/search_trackplaylist.txt")
 	result, err := client.Search("holiday", SearchTypePlaylist|SearchTypeTrack)


### PR DESCRIPTION
Hi, 

I found this today and started using it but encountered an issue when trying to search with filters in the query string. I think I've tracked down the issue and my before/after testing seems to indicate that the call to `url.QueryEscape` is the issue. I've only lightly tested it (ran `go test` and tried my example).

I added a unit test that fails without this fix, and passes with the fix. I didn't really know how to name it, or where to place it. I can modify that if you'd like. I used your example of Uptown Funk, but used the filter parameter to search for Bruno Mars since he's a featured artist.