### PR TITLE
Fix parameter for adding tracks to playlist: should be "uris"

### DIFF
--- a/playlist.go
+++ b/playlist.go
@@ -440,7 +440,7 @@ func (c *Client) AddTracksToPlaylist(userID string, playlistID ID,
 	for i, id := range trackIDs {
 		uris[i] = fmt.Sprintf("spotify:track:%s", id)
 	}
-	spotifyURL := fmt.Sprintf("%susers/%s/playlists/%s/tracks?urls=%s",
+	spotifyURL := fmt.Sprintf("%susers/%s/playlists/%s/tracks?uris=%s",
 		baseAddress, userID, string(playlistID), strings.Join(uris, ","))
 	req, err := http.NewRequest("POST", spotifyURL, nil)
 	if err != nil {


### PR DESCRIPTION
Fixes a bug in the library that causes in adding tracks to a playlist
currently being non-functional. The library passes "urls", but [as
described in the documentation][doc], it should actually be "uris".

[doc]: https://developer.spotify.com/web-api/console/post-playlist-tracks/#complete