### PR TITLE
Fix ExternalURL collections

### DIFF
--- a/album.go
+++ b/album.go
@@ -49,7 +49,7 @@ type SimpleAlbum struct {
 	// widest first.
 	Images []Image `json:"images"`
 	// Known external URLs for this album.
-	ExternalURLs ExternalURL `json:"external_urls"`
+	ExternalURLs map[string]string `json:"external_urls"`
 }
 
 // Copyright contains the copyright statement associated with an album.

--- a/artist.go
+++ b/artist.go
@@ -31,7 +31,7 @@ type SimpleArtist struct {
 	URI URI `json:"uri"`
 	// A link to the Web API enpoint providing full details of the artist.
 	Endpoint     string      `json:"href"`
-	ExternalURLs ExternalURL `json:"external_urls"`
+	ExternalURLs map[string]string `json:"external_urls"`
 }
 
 // FullArtist provides extra artist data in addition to what is provided by SimpleArtist.

--- a/playlist.go
+++ b/playlist.go
@@ -38,7 +38,7 @@ type SimplePlaylist struct {
 	// Indicates whether the playlist owner allows others to modify the playlist.
 	// Note: only non-collaborative playlists are currently returned by Spotify's Web API.
 	Collaborative bool        `json:"collaborative"`
-	ExternalURLs  ExternalURL `json:"external_urls"`
+	ExternalURLs  map[string]string `json:"external_urls"`
 	// A link to the Web API endpoint providing full details of the playlist.
 	Endpoint string `json:"href"`
 	ID       ID     `json:"id"`

--- a/spotify.go
+++ b/spotify.go
@@ -133,15 +133,6 @@ type ExternalID struct {
 	Value string `json:"{value}"`
 }
 
-// ExternalURL indicates an external, public URL for an item.
-type ExternalURL struct {
-	// The type of the URL, for example:
-	//    "spotify" - The Spotify URL for the object.
-	Key string `json:"{key}"`
-	// An external, public URL to the object.
-	Value string `json:"{value}"`
-}
-
 // Client is a client for working with the Spotify Web API.
 // To create an authenticated client, use the
 // `Authenticator.NewClient` method.  If you don't need to

--- a/track.go
+++ b/track.go
@@ -36,7 +36,7 @@ type SimpleTrack struct {
 	// true => yes, it does; false => no, it does not.
 	Explicit bool `json:"explicit"`
 	// External URLs for this track.
-	ExternalURLs ExternalURL `json:"external_urls"`
+	ExternalURLs map[string]string `json:"external_urls"`
 	// A link to the Web API endpoint providing full details for this track.
 	Endpoint string `json:"href"`
 	ID       ID     `json:"id"`

--- a/user.go
+++ b/user.go
@@ -31,7 +31,7 @@ type User struct {
 	// this field when querying for a playlist.
 	DisplayName string `json:"display_name"`
 	// Known public external URLs for the user.
-	ExternalURLs ExternalURL `json:"external_urls"`
+	ExternalURLs map[string]string `json:"external_urls"`
 	// Information about followers of the user.
 	Followers Followers `json:"followers"`
 	// A link to the Web API endpoint for this user.


### PR DESCRIPTION
The current implementation seem to map these collections to a single struct
(the `ExternalURL` type) containing a Key/Value which in practice doesn't
unmarshal to anything. As dictated by the documentation [1], these are simple
objects mapping a string to a string and that's unlikely to change during this
API version, so I'd recommend using a simple map instead (for user
convenience).

The `ExternalURL` seems to be using the special JSON annotations of
`json:"{key}"`, which I would guess are supposed to help unmarshal an object,
but I couldn't find any record of them online (and as noted above, the singular
nature of the resources will prevent a successful unmarshaling anyway, I think
at the very least you'd want `[]ExternalURL`).

Note that `ExternalIDs` have the same problem, but are not addressed in this
pull.

[1] https://developer.spotify.com/web-api/get-playlist/