### PR TITLE
Change http client of oauth2 to force HTTP/1

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -99,7 +99,7 @@ func NewAuthenticator(redirectURL string, scopes ...string) Authenticator {
 	tr := &http.Transport{
 		TLSNextProto: map[string]func(authority string, c *tls.Conn) http.RoundTripper{},
 	}
-	ctx := context.WithValue(context.TODO(), oauth2.HTTPClient, &http.Client{Transport: tr})
+	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, &http.Client{Transport: tr})
 	return Authenticator{
 		config:  cfg,
 		context: ctx,

--- a/spotify.go
+++ b/spotify.go
@@ -3,6 +3,7 @@
 package spotify
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"io"
@@ -41,6 +42,17 @@ type URI string
 // ID is a base-62 identifier for an artist, track, album, etc.
 // It can be found at the end of a spotify.URI.
 type ID string
+
+func init() {
+	// The default http.Transport should be overriden giving a non nil value to TLSNextProto
+	// to force HTTP/1, as discussed in https://github.com/zmb3/spotify/issues/20.
+	// According to the documentation, this is the only way it can be done
+	// (https://golang.org/src/net/http/transport.go, line 195)
+	tr := &http.Transport{
+		TLSNextProto: map[string]func(authority string, c *tls.Conn) http.RoundTripper{},
+	}
+	DefaultClient.http.Transport = tr
+}
 
 func (id *ID) String() string {
 	return string(*id)


### PR DESCRIPTION
As discussed in #20, oauth2 used HTTP/2 for authenticating the user. Now, the old `auth2.NoContext` has been substituted by `context.Context` and the default `http.Client` has been overrided as stated in the [documentation](https://golang.org/pkg/net/http/#pkg-overview) for using HTTP/1