### PR TITLE
Add GetAvailableGenreSeeds() method

### DIFF
--- a/recommendation.go
+++ b/recommendation.go
@@ -114,3 +114,24 @@ func (c *Client) GetRecommendations(seeds Seeds, trackAttributes *TrackAttribute
 	}
 	return &recommendations, err
 }
+
+// GetAvailableGenreSeeds retrieves a list of available genres seed parameter values for
+// recommendations.
+func (c *Client) GetAvailableGenreSeeds() ([]string, error) {
+	spotifyURL := baseAddress + "recommendations/available-genre-seeds"
+	resp, err := c.http.Get(spotifyURL)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, decodeError(resp.Body)
+	}
+	genreSeeds := make(map[string][]string)
+	err = json.NewDecoder(resp.Body).Decode(&genreSeeds)
+	if err != nil {
+		return nil, err
+	}
+	return genreSeeds["genres"], nil
+}


### PR DESCRIPTION
Add GetAvailableGenreSeeds() method as per https://developer.spotify.com/web-api/console/get-available-genre-seeds/

I had need of this functionality to populate a list of allowable seed genres for creating playlists based on recommendations.

I haven't added tests for this method, as I'm not sure how to go about comparing the output to a static list, as the output from Spotify may change over time.