### PR TITLE
Fix Invalid Type error in CurrentUsersFollowedArtistsOpt

### DIFF
--- a/user.go
+++ b/user.go
@@ -263,8 +263,9 @@ func (c *Client) CurrentUsersFollowedArtists() (*FullArtistCursorPage, error) {
 // wish to specify either of the parameters, use -1 for limit and the empty
 // string for after.
 func (c *Client) CurrentUsersFollowedArtistsOpt(limit int, after string) (*FullArtistCursorPage, error) {
-	spotifyURL := baseAddress + "me/following?type=artist"
+	spotifyURL := baseAddress + "me/following"
 	v := url.Values{}
+	v.Set("type", "artist")
 	if limit != -1 {
 		v.Set("limit", strconv.Itoa(limit))
 	}

--- a/user_test.go
+++ b/user_test.go
@@ -320,3 +320,14 @@ func TestUsersFollowedArtists(t *testing.T) {
 		t.Error("Got wrong artist name")
 	}
 }
+
+func TestCurrentUsersFollowedArtistsOpt(t *testing.T) {
+	client := testClientString(http.StatusOK, "{}")
+	addDummyAuth(client)
+	client.CurrentUsersFollowedArtistsOpt(50, "0aV6DOiouImYTqrR5YlIqx")
+	requestURL := getLastRequest(client).URL.String()
+	exp := baseAddress + "me/following?after=0aV6DOiouImYTqrR5YlIqx&limit=50&type=artist"
+	if requestURL != exp {
+		t.Errorf("Expected requested URL to be %s, got %s ", exp, requestURL)
+	}
+}


### PR DESCRIPTION
When passing something other than the default values to
`CurrentUsersFollowedArtistsOpt`, the client returns an error
like "Invalid type: artist?limit=50".