### PR TITLE
Add support for Get Audio Analysis

### DIFF
--- a/audio_analysis.go
+++ b/audio_analysis.go
@@ -8,29 +8,24 @@ import (
 
 // AudioAnalysis contains a detailed audio analysis for a single track identified by its unique Spotify ID.
 // See https://developer.spotify.com/web-api/get-audio-analysis/
-//
-// Spotify's documentation is currently missing the object model for the AudioAnalysis.
-// See https://github.com/spotify/web-api/issues/317
-//
-// Also see The Echo Nest documentation
-// https://web.archive.org/web/20160528174915/http://developer.echonest.com/docs/v4/_static/AnalyzeDocumentation.pdf
 type AudioAnalysis struct {
-	Bars     []Measure          `json:"bars"`
-	Beats    []Measure          `json:"beats"`
+	Bars     []Marker           `json:"bars"`
+	Beats    []Marker           `json:"beats"`
 	Meta     AudioAnalysisMeta  `json:"meta"`
 	Sections []Section          `json:"sections"`
 	Segments []Segment          `json:"segments"`
-	Tatums   []Measure          `json:"tatums"`
+	Tatums   []Marker           `json:"tatums"`
 	Track    AudioAnalysisTrack `json:"track"`
 }
 
-// Measure represents beats, bars, tatums and are used in segments and sections descriptions.
-type Measure struct {
+// Marker represents beats, bars, tatums and are used in segment and section descriptions.
+type Marker struct {
 	Start      float64 `json:"start"`
 	Duration   float64 `json:"duration"`
 	Confidence float64 `json:"confidence"`
 }
 
+// AudioAnalysisMeta describes details about Spotify's analysis of the track
 type AudioAnalysisMeta struct {
 	AnalyzerVersion string  `json:"analyzer_version"`
 	Platform        string  `json:"platform"`
@@ -41,21 +36,24 @@ type AudioAnalysisMeta struct {
 	InputProcess    string  `json:"input_process"`
 }
 
+// A Section represents a large variation in rhythm or timbre, e.g. chorus, verse, bridge, guitar solo, etc.
+// Each section contains its own descriptions of tempo, key, mode, time_signature, and loudness.
 type Section struct {
-	Measure
+	Marker
 	Loudness                float64 `json:"loudness"`
 	Tempo                   float64 `json:"tempo"`
 	TempoConfidence         float64 `json:"tempo_confidence"`
-	Key                     int     `json:"key"`
+	Key                     Key     `json:"key"`
 	KeyConfidence           float64 `json:"key_confidence"`
-	Mode                    int     `json:"mode"`
+	Mode                    Mode    `json:"mode"`
 	ModeConfidence          float64 `json:"mode_confidence"`
 	TimeSignature           int     `json:"time_signature"`
 	TimeSignatureConfidence float64 `json:"time_signature_confidence"`
 }
 
+// A Segment is characterized by it's perceptual onset and duration in seconds, loudness (dB), pitch and timbral content.
 type Segment struct {
-	Measure
+	Marker
 	LoudnessStart   float64   `json:"loudness_start"`
 	LoudnessMaxTime float64   `json:"loudness_max_time"`
 	LoudnessMax     float64   `json:"loudness_max"`
@@ -64,6 +62,7 @@ type Segment struct {
 	Timbre          []float64 `json:"timbre"`
 }
 
+// AudioAnalysisTrack contains data about the track as a whole
 type AudioAnalysisTrack struct {
 	NumSamples              int64   `json:"num_samples"`
 	Duration                float64 `json:"duration"`
@@ -94,7 +93,6 @@ type AudioAnalysisTrack struct {
 }
 
 // GetAudioAnalysis queries the Spotify web API for an audio analysis of a single track
-// If an object is not found, a nil value is returned in the appropriate position.
 // This call requires authorization.
 func (c *Client) GetAudioAnalysis(id ID) (*AudioAnalysis, error) {
 	url := fmt.Sprintf("%saudio-analysis/%s", baseAddress, id)

--- a/audio_analysis.go
+++ b/audio_analysis.go
@@ -1,0 +1,119 @@
+package spotify
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// AudioAnalysis contains a detailed audio analysis for a single track identified by its unique Spotify ID.
+// See https://developer.spotify.com/web-api/get-audio-analysis/
+//
+// Spotify's documentation is currently missing the object model for the AudioAnalysis.
+// See https://github.com/spotify/web-api/issues/317
+//
+// Also see The Echo Nest documentation
+// https://web.archive.org/web/20160528174915/http://developer.echonest.com/docs/v4/_static/AnalyzeDocumentation.pdf
+type AudioAnalysis struct {
+	Bars     []Measure          `json:"bars"`
+	Beats    []Measure          `json:"beats"`
+	Meta     AudioAnalysisMeta  `json:"meta"`
+	Sections []Section          `json:"sections"`
+	Segments []Segment          `json:"segments"`
+	Tatums   []Measure          `json:"tatums"`
+	Track    AudioAnalysisTrack `json:"track"`
+}
+
+// Measure represents beats, bars, tatums and are used in segments and sections descriptions.
+type Measure struct {
+	Start      float64 `json:"start"`
+	Duration   float64 `json:"duration"`
+	Confidence float64 `json:"confidence"`
+}
+
+type AudioAnalysisMeta struct {
+	AnalyzerVersion string  `json:"analyzer_version"`
+	Platform        string  `json:"platform"`
+	DetailedStatus  string  `json:"detailed_status"`
+	StatusCode      int     `json:"status"`
+	Timestamp       int64   `json:"timestamp"`
+	AnalysisTime    float64 `json:"analysis_time"`
+	InputProcess    string  `json:"input_process"`
+}
+
+type Section struct {
+	Measure
+	Loudness                float64 `json:"loudness"`
+	Tempo                   float64 `json:"tempo"`
+	TempoConfidence         float64 `json:"tempo_confidence"`
+	Key                     int     `json:"key"`
+	KeyConfidence           float64 `json:"key_confidence"`
+	Mode                    int     `json:"mode"`
+	ModeConfidence          float64 `json:"mode_confidence"`
+	TimeSignature           int     `json:"time_signature"`
+	TimeSignatureConfidence float64 `json:"time_signature_confidence"`
+}
+
+type Segment struct {
+	Measure
+	LoudnessStart   float64   `json:"loudness_start"`
+	LoudnessMaxTime float64   `json:"loudness_max_time"`
+	LoudnessMax     float64   `json:"loudness_max"`
+	LoudnessEnd     float64   `json:"loudness_end"`
+	Pitches         []float64 `json:"pitches"`
+	Timbre          []float64 `json:"timbre"`
+}
+
+type AudioAnalysisTrack struct {
+	NumSamples              int64   `json:"num_samples"`
+	Duration                float64 `json:"duration"`
+	SampleMD5               string  `json:"sample_md5"`
+	OffsetSeconds           int     `json:"offset_seconds"`
+	WindowSeconds           int     `json:"window_seconds"`
+	AnalysisSampleRate      int64   `json:"analysis_sample_rate"`
+	AnalysisChannels        int     `json:"analysis_channels"`
+	EndOfFadeIn             float64 `json:"end_of_fade_in"`
+	StartOfFadeOut          float64 `json:"start_of_fade_out"`
+	Loudness                float64 `json:"loudness"`
+	Tempo                   float64 `json:"tempo"`
+	TempoConfidence         float64 `json:"tempo_confidence"`
+	TimeSignature           int     `json:"time_signature"`
+	TimeSignatureConfidence float64 `json:"time_signature_confidence"`
+	Key                     Key     `json:"key"`
+	KeyConfidence           float64 `json:"key_confidence"`
+	Mode                    Mode    `json:"mode"`
+	ModeConfidence          float64 `json:"mode_confidence"`
+	CodeString              string  `json:"codestring"`
+	CodeVersion             float64 `json:"code_version"`
+	EchoprintString         string  `json:"echoprintstring"`
+	EchoprintVersion        float64 `json:"echoprint_version"`
+	SynchString             string  `json:"synchstring"`
+	SynchVersion            float64 `json:"synch_version"`
+	RhythmString            string  `json:"rhythmstring"`
+	RhythmVersion           float64 `json:"rhythm_version"`
+}
+
+// GetAudioAnalysis queries the Spotify web API for an audio analysis of a single track
+// If an object is not found, a nil value is returned in the appropriate position.
+// This call requires authorization.
+func (c *Client) GetAudioAnalysis(id ID) (*AudioAnalysis, error) {
+	url := fmt.Sprintf("%saudio-analysis/%s", baseAddress, id)
+
+	resp, err := c.http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, decodeError(resp.Body)
+	}
+
+	temp := AudioAnalysis{}
+	err = json.NewDecoder(resp.Body).Decode(&temp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &temp, nil
+}

--- a/audio_analysis_test.go
+++ b/audio_analysis_test.go
@@ -6,17 +6,17 @@ import (
 	"testing"
 )
 
-const FIELDS_DIFFER_TEMPLATE = "Actual response is not the same as expected response on field %s"
+const fieldsDifferTemplate = "Actual response is not the same as expected response on field %s"
 
 var expected = AudioAnalysis{
-	Bars: []Measure{
+	Bars: []Marker{
 		{
 			Start:      251.98282,
 			Duration:   0.29765,
 			Confidence: 0.652,
 		},
 	},
-	Beats: []Measure{
+	Beats: []Marker{
 		{
 			Start:      251.98282,
 			Duration:   0.29765,
@@ -34,7 +34,7 @@ var expected = AudioAnalysis{
 	},
 	Sections: []Section{
 		{
-			Measure: Measure{
+			Marker: Marker{
 				Start:      237.02356,
 				Duration:   18.32542,
 				Confidence: 1,
@@ -52,7 +52,7 @@ var expected = AudioAnalysis{
 	},
 	Segments: []Segment{
 		{
-			Measure: Measure{
+			Marker: Marker{
 				Start:      252.15601,
 				Duration:   3.19297,
 				Confidence: 0.522,
@@ -65,7 +65,7 @@ var expected = AudioAnalysis{
 			Timbre:          []float64{23.312, -7.374, -45.719, 294.874, 51.869, -79.384, -89.048, 143.322, -4.676, -51.303, -33.274, -19.037},
 		},
 	},
-	Tatums: []Measure{
+	Tatums: []Marker{
 		{
 			Start:      251.98282,
 			Duration:   0.29765,
@@ -103,7 +103,6 @@ var expected = AudioAnalysis{
 }
 
 func TestAudioAnalysis(t *testing.T) {
-
 	c := testClientFile(http.StatusOK, "test_data/get_audio_analysis.txt")
 	addDummyAuth(c)
 
@@ -113,30 +112,30 @@ func TestAudioAnalysis(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(analysis.Bars, expected.Bars) {
-		t.Errorf(FIELDS_DIFFER_TEMPLATE, "Bars")
+		t.Errorf(fieldsDifferTemplate, "Bars")
 	}
 
 	if !reflect.DeepEqual(analysis.Beats, expected.Beats) {
-		t.Errorf(FIELDS_DIFFER_TEMPLATE, "Beats")
+		t.Errorf(fieldsDifferTemplate, "Beats")
 	}
 
 	if !reflect.DeepEqual(analysis.Meta, expected.Meta) {
-		t.Errorf(FIELDS_DIFFER_TEMPLATE, "Meta")
+		t.Errorf(fieldsDifferTemplate, "Meta")
 	}
 
 	if !reflect.DeepEqual(analysis.Sections, expected.Sections) {
-		t.Errorf(FIELDS_DIFFER_TEMPLATE, "Sections")
+		t.Errorf(fieldsDifferTemplate, "Sections")
 	}
 
 	if !reflect.DeepEqual(analysis.Segments, expected.Segments) {
-		t.Errorf(FIELDS_DIFFER_TEMPLATE, "Segments")
+		t.Errorf(fieldsDifferTemplate, "Segments")
 	}
 
 	if !reflect.DeepEqual(analysis.Track, expected.Track) {
-		t.Errorf(FIELDS_DIFFER_TEMPLATE, "Track")
+		t.Errorf(fieldsDifferTemplate, "Track")
 	}
 
 	if !reflect.DeepEqual(analysis.Tatums, expected.Tatums) {
-		t.Errorf(FIELDS_DIFFER_TEMPLATE, "Tatums")
+		t.Errorf(fieldsDifferTemplate, "Tatums")
 	}
 }

--- a/audio_analysis_test.go
+++ b/audio_analysis_test.go
@@ -1,0 +1,142 @@
+package spotify
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+const FIELDS_DIFFER_TEMPLATE = "Actual response is not the same as expected response on field %s"
+
+var expected = AudioAnalysis{
+	Bars: []Measure{
+		{
+			Start:      251.98282,
+			Duration:   0.29765,
+			Confidence: 0.652,
+		},
+	},
+	Beats: []Measure{
+		{
+			Start:      251.98282,
+			Duration:   0.29765,
+			Confidence: 0.652,
+		},
+	},
+	Meta: AudioAnalysisMeta{
+		AnalyzerVersion: "4.0.0",
+		Platform:        "Linux",
+		DetailedStatus:  "OK",
+		StatusCode:      0,
+		Timestamp:       1456010389,
+		AnalysisTime:    9.1394,
+		InputProcess:    "libvorbisfile L+R 44100->22050",
+	},
+	Sections: []Section{
+		{
+			Measure: Measure{
+				Start:      237.02356,
+				Duration:   18.32542,
+				Confidence: 1,
+			},
+			Loudness:                -20.074,
+			Tempo:                   98.253,
+			TempoConfidence:         0.767,
+			Key:                     5,
+			KeyConfidence:           0.327,
+			Mode:                    1,
+			ModeConfidence:          0.566,
+			TimeSignature:           4,
+			TimeSignatureConfidence: 1,
+		},
+	},
+	Segments: []Segment{
+		{
+			Measure: Measure{
+				Start:      252.15601,
+				Duration:   3.19297,
+				Confidence: 0.522,
+			},
+			LoudnessStart:   -23.356,
+			LoudnessMaxTime: 0.06971,
+			LoudnessMax:     -18.121,
+			LoudnessEnd:     -60,
+			Pitches:         []float64{0.709, 0.092, 0.196, 0.084, 0.352, 0.134, 0.161, 1, 0.17, 0.161, 0.211, 0.15},
+			Timbre:          []float64{23.312, -7.374, -45.719, 294.874, 51.869, -79.384, -89.048, 143.322, -4.676, -51.303, -33.274, -19.037},
+		},
+	},
+	Tatums: []Measure{
+		{
+			Start:      251.98282,
+			Duration:   0.29765,
+			Confidence: 0.652,
+		},
+	},
+	Track: AudioAnalysisTrack{
+		NumSamples:              100,
+		Duration:                255.34898,
+		SampleMD5:               "",
+		OffsetSeconds:           0,
+		WindowSeconds:           0,
+		AnalysisSampleRate:      22050,
+		AnalysisChannels:        1,
+		EndOfFadeIn:             0,
+		StartOfFadeOut:          251.73333,
+		Loudness:                -11.84,
+		Tempo:                   98.002,
+		TempoConfidence:         0.423,
+		TimeSignature:           4,
+		TimeSignatureConfidence: 1,
+		Key:              5,
+		KeyConfidence:    0.36,
+		Mode:             0,
+		ModeConfidence:   0.414,
+		CodeString:       "eJxVnAmS5DgOBL-ST-B9_P9j4x7M6qoxW9tpsZQSCeI...",
+		CodeVersion:      3.15,
+		EchoprintString:  "eJzlvQmSHDmStHslxw4cB-v9j_A-tahhVKV0IH9...",
+		EchoprintVersion: 4.12,
+		SynchString:      "eJx1mIlx7ToORFNRCCK455_YoE9Dtt-vmrKsK3EBsTY...",
+		SynchVersion:     1,
+		RhythmString:     "eJyNXAmOLT2r28pZQuZh_xv7g21Iqu_3pCd160xV...",
+		RhythmVersion:    1,
+	},
+}
+
+func TestAudioAnalysis(t *testing.T) {
+
+	c := testClientFile(http.StatusOK, "test_data/get_audio_analysis.txt")
+	addDummyAuth(c)
+
+	analysis, err := c.GetAudioAnalysis("foo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(analysis.Bars, expected.Bars) {
+		t.Errorf(FIELDS_DIFFER_TEMPLATE, "Bars")
+	}
+
+	if !reflect.DeepEqual(analysis.Beats, expected.Beats) {
+		t.Errorf(FIELDS_DIFFER_TEMPLATE, "Beats")
+	}
+
+	if !reflect.DeepEqual(analysis.Meta, expected.Meta) {
+		t.Errorf(FIELDS_DIFFER_TEMPLATE, "Meta")
+	}
+
+	if !reflect.DeepEqual(analysis.Sections, expected.Sections) {
+		t.Errorf(FIELDS_DIFFER_TEMPLATE, "Sections")
+	}
+
+	if !reflect.DeepEqual(analysis.Segments, expected.Segments) {
+		t.Errorf(FIELDS_DIFFER_TEMPLATE, "Segments")
+	}
+
+	if !reflect.DeepEqual(analysis.Track, expected.Track) {
+		t.Errorf(FIELDS_DIFFER_TEMPLATE, "Track")
+	}
+
+	if !reflect.DeepEqual(analysis.Tatums, expected.Tatums) {
+		t.Errorf(FIELDS_DIFFER_TEMPLATE, "Tatums")
+	}
+}

--- a/test_data/get_audio_analysis.txt
+++ b/test_data/get_audio_analysis.txt
@@ -1,0 +1,114 @@
+{"bars": [
+    {
+      "start": 251.98282,
+      "duration": 0.29765,
+      "confidence": 0.652
+    }
+  ],
+  "beats": [
+    {
+      "start": 251.98282,
+      "duration": 0.29765,
+      "confidence": 0.652
+    }
+  ],
+  "meta": {
+    "analyzer_version": "4.0.0",
+    "platform": "Linux",
+    "detailed_status": "OK",
+    "status_code": 0,
+    "timestamp": 1456010389,
+    "analysis_time": 9.1394,
+    "input_process": "libvorbisfile L+R 44100->22050"
+  },
+  "sections": [
+    {
+      "start": 237.02356,
+      "duration": 18.32542,
+      "confidence": 1,
+      "loudness": -20.074,
+      "tempo": 98.253,
+      "tempo_confidence": 0.767,
+      "key": 5,
+      "key_confidence": 0.327,
+      "mode": 1,
+      "mode_confidence": 0.566,
+      "time_signature": 4,
+      "time_signature_confidence": 1
+    }
+  ],
+  "segments": [
+    {
+      "start": 252.15601,
+      "duration": 3.19297,
+      "confidence": 0.522,
+      "loudness_start": -23.356,
+      "loudness_max_time": 0.06971,
+      "loudness_max": -18.121,
+      "loudness_end": -60,
+      "pitches": [
+        0.709,
+        0.092,
+        0.196,
+        0.084,
+        0.352,
+        0.134,
+        0.161,
+        1,
+        0.17,
+        0.161,
+        0.211,
+        0.15
+      ],
+      "timbre": [
+        23.312,
+        -7.374,
+        -45.719,
+        294.874,
+        51.869,
+        -79.384,
+        -89.048,
+        143.322,
+        -4.676,
+        -51.303,
+        -33.274,
+        -19.037
+      ]
+    }
+  ],
+  "tatums": [
+    {
+      "start": 251.98282,
+      "duration": 0.29765,
+      "confidence": 0.652
+    }
+  ],
+  "track": {
+    "num_samples": 100,
+    "duration": 255.34898,
+    "sample_md5": "",
+    "offset_seconds": 0,
+    "window_seconds": 0,
+    "analysis_sample_rate": 22050,
+    "analysis_channels": 1,
+    "end_of_fade_in": 0,
+    "start_of_fade_out": 251.73333,
+    "loudness": -11.84,
+    "tempo": 98.002,
+    "tempo_confidence": 0.423,
+    "time_signature": 4,
+    "time_signature_confidence": 1,
+    "key": 5,
+    "key_confidence": 0.36,
+    "mode": 0,
+    "mode_confidence": 0.414,
+    "codestring": "eJxVnAmS5DgOBL-ST-B9_P9j4x7M6qoxW9tpsZQSCeI...",
+    "code_version": 3.15,
+    "echoprintstring": "eJzlvQmSHDmStHslxw4cB-v9j_A-tahhVKV0IH9...",
+    "echoprint_version": 4.12,
+    "synchstring": "eJx1mIlx7ToORFNRCCK455_YoE9Dtt-vmrKsK3EBsTY...",
+    "synch_version": 1,
+    "rhythmstring": "eJyNXAmOLT2r28pZQuZh_xv7g21Iqu_3pCd160xV...",
+    "rhythm_version": 1
+  }
+}


### PR DESCRIPTION
AudioAnalysis contains a detailed audio analysis for a single track identified by its unique Spotify ID. See https://developer.spotify.com/web-api/get-audio-analysis/ 

Spotify's documentation is currently missing the object model for the AudioAnalysis. See https://github.com/spotify/web-api/issues/317

Also see The Echo Nest documentation https://web.archive.org/web/20160528174915/http://developer.echonest.com/docs/v4/_static/AnalyzeDocumentation.pdf