### PR TITLE
Fix Previous() to stop skipping to next track

### DIFF
--- a/player.go
+++ b/player.go
@@ -343,7 +343,7 @@ func (c *Client) NextOpt(opt *PlayOptions) error {
 //
 // Requires the ScopeUserModifyPlaybackState in order to modify the player state
 func (c *Client) Previous() error {
-	return c.NextOpt(nil)
+	return c.PreviousOpt(nil)
 }
 
 // PreviousOpt is like Previous but with more options


### PR DESCRIPTION
Currently, `Previous()` calls `NextOpt(nil)` instead of `PreviousOpt(nil)` causing a skip to the next track instead of correctly skipping to the previous track.