### PR TITLE
Unmarshalling NewReleases response into a map 

### DIFF
--- a/spotify_test.go
+++ b/spotify_test.go
@@ -106,9 +106,14 @@ func addDummyAuth(c *Client) {
 func TestNewReleases(t *testing.T) {
 	c := testClientFile(http.StatusOK, "test_data/new_releases.txt")
 	addDummyAuth(c)
-	_, err := c.NewReleases()
+	r, err := c.NewReleases()
 	if err != nil {
 		t.Error(err)
+		return
+	}
+	var r1 *SimpleAlbumPage
+	if r == r1 {
+		t.Error("Empty SimpleAlbumPage")
 		return
 	}
 }

--- a/spotify_test.go
+++ b/spotify_test.go
@@ -111,9 +111,12 @@ func TestNewReleases(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	var r1 *SimpleAlbumPage
-	if r == r1 {
-		t.Error("Empty SimpleAlbumPage")
+	if r.Albums[0].ID != "60mvULtYiNSRmpVvoa3RE4" {
+		t.Error("Invalid data: ", r.Albums[0].ID)
+		return
+	}
+	if r.Albums[0].Name != "We Are One (Ole Ola) [The Official 2014 FIFA World Cup Song]" {
+		t.Error("Invalid data", r.Albums[0].Name)
 		return
 	}
 }


### PR DESCRIPTION
Fixes #34. The issue was caused by the WebAPI responding to `NewReleases` with this format: 

Specifically note, `"albums" : {`

```json
{
  "albums" : {
    "href" : "https://api.spotify.com/v1/browse/new-releases?offset=0&limit=20",
    "items" : [ {
      "album_type" : "single",
      "artists" : [ {
        "external_urls" : {
          "spotify" : "https://open.spotify.com/artist/2h93pZq0e7k5yf4dywlkpM"
        },
        "href" : "https://api.spotify.com/v1/artists/2h93pZq0e7k5yf4dywlkpM",
        "id" : "2h93pZq0e7k5yf4dywlkpM",
        "name" : "Frank Ocean",
        "type" : "artist",
        "uri" : "spotify:artist:2h93pZq0e7k5yf4dywlkpM"
      } ],
      "available_markets" : [],
      "external_urls" : {
        "spotify" : "https://open.spotify.com/album/7yOOPJjNelITCaYMqk8V6r"
      },
      "href" : "https://api.spotify.com/v1/albums/7yOOPJjNelITCaYMqk8V6r",
      "id" : "7yOOPJjNelITCaYMqk8V6r",
      "images" : [ { } ],
      "name" : "Biking",
      "type" : "album",
      "uri" : "spotify:album:7yOOPJjNelITCaYMqk8V6r"
    },
```

Whereas the other functions, i.e. `GetArtistAlbums(artistID ID) (*SimpleAlbumPage, error)`, receive a response formatted without the top level `albums`: 

```json
{
  "href" : "https://api.spotify.com/v1/artists/4tZwfgrHOc3mvqYlEYSvVi/albums?offset=0&limit=20&album_type=single,album,compilation,appears_on,ep",
  "items" : [ {
    "album_type" : "album",
    "artists" : [ {
      "external_urls" : {
        "spotify" : "https://open.spotify.com/artist/4tZwfgrHOc3mvqYlEYSvVi"
      },
      "href" : "https://api.spotify.com/v1/artists/4tZwfgrHOc3mvqYlEYSvVi",
      "id" : "4tZwfgrHOc3mvqYlEYSvVi",
      "name" : "Daft Punk",
      "type" : "artist",
      "uri" : "spotify:artist:4tZwfgrHOc3mvqYlEYSvVi"
    } ],
    "available_markets" : [  ],
    "external_urls" : {
      "spotify" : "https://open.spotify.com/album/4m2880jivSbbyEGAKfITCa"
    },
    "href" : "https://api.spotify.com/v1/albums/4m2880jivSbbyEGAKfITCa",
    "id" : "4m2880jivSbbyEGAKfITCa",
    "images" : [ { } ],
    "name" : "Random Access Memories",
    "type" : "album",
    "uri" : "spotify:album:4m2880jivSbbyEGAKfITCa"
  },
```

This is fixed by first unmarshalling the response into a map and then parsing the response into a SimpleAlbumPage to pass it the `albums` values. I've tested this and it is working on my machine. 
