### PR TITLE
Added automatic-retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ omits optional parameters and uses reasonable defaults, and a more sophisticated
 version that accepts additional parameters.  The latter is suffixed with `Opt`
 to indicate that it accepts some optional parameters.
 
+### Automatic Retries
+
+The API will throttle your requests if you are sending them too rapidly. This client can automatically wait and reattempt the request, but this does not happen automatically. To enable this, call `spotify.SetAutoRetry(true)`.
+
+For more information, see Spotify [rate-limits](https://developer.spotify.com/web-api/user-guide/#rate-limiting).
+
 ## API Examples
 
 Examples of the API can be found in the [examples](examples) directory.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ to indicate that it accepts some optional parameters.
 
 ### Automatic Retries
 
-The API will throttle your requests if you are sending them too rapidly. This client can automatically wait and reattempt the request, but this does not happen automatically. To enable this, call `spotify.SetAutoRetry(true)`.
+The API will throttle your requests if you are sending them too rapidly. This client can automatically wait and reattempt the request, but this does not happen automatically. To enable this, call `SetAutoRetry(true)` on the `*Client` struct.
 
 For more information, see Spotify [rate-limits](https://developer.spotify.com/web-api/user-guide/#rate-limiting).
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ to indicate that it accepts some optional parameters.
 
 ### Automatic Retries
 
-The API will throttle your requests if you are sending them too rapidly. This client can automatically wait and reattempt the request, but this does not happen automatically. To enable this, call `SetAutoRetry(true)` on the `*Client` struct.
+The API will throttle your requests if you are sending them too rapidly. This client can automatically wait and reattempt the request, but this does not happen automatically. To enable this, set the `AutoRetry` field on the `Client` struct to `true`.
 
 For more information, see Spotify [rate-limits](https://developer.spotify.com/web-api/user-guide/#rate-limiting).
 

--- a/album.go
+++ b/album.go
@@ -97,10 +97,10 @@ func (f *FullAlbum) ReleaseDateTime() time.Time {
 // GetAlbum gets Spotify catalog information for a single album, given its Spotify ID.
 func (c *Client) GetAlbum(id ID) (*FullAlbum, error) {
 	spotifyURL := fmt.Sprintf("%salbums/%s", baseAddress, id)
-	
+
 	var a FullAlbum
 
-	err := c.Get(spotifyURL, &a)
+	err := c.get(spotifyURL, &a)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (c *Client) GetAlbums(ids ...ID) ([]*FullAlbum, error) {
 		Albums []*FullAlbum `json:"albums"`
 	}
 
-	err := c.Get(spotifyURL, &a)
+	err := c.get(spotifyURL, &a)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (c *Client) GetAlbumTracksOpt(id ID, limit, offset int) (*SimpleTrackPage, 
 	}
 
 	var result SimpleTrackPage
-	err := c.Get(spotifyURL, &result)
+	err := c.get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/album.go
+++ b/album.go
@@ -1,10 +1,8 @@
 package spotify
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -99,19 +97,14 @@ func (f *FullAlbum) ReleaseDateTime() time.Time {
 // GetAlbum gets Spotify catalog information for a single album, given its Spotify ID.
 func (c *Client) GetAlbum(id ID) (*FullAlbum, error) {
 	spotifyURL := fmt.Sprintf("%salbums/%s", baseAddress, id)
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+	
 	var a FullAlbum
-	err = json.NewDecoder(resp.Body).Decode(&a)
+
+	err := c.Get(spotifyURL, &a)
 	if err != nil {
 		return nil, err
 	}
+
 	return &a, nil
 }
 
@@ -137,21 +130,16 @@ func (c *Client) GetAlbums(ids ...ID) ([]*FullAlbum, error) {
 		return nil, errors.New("spotify: exceeded maximum number of albums")
 	}
 	spotifyURL := fmt.Sprintf("%salbums?ids=%s", baseAddress, strings.Join(toStringSlice(ids), ","))
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+
 	var a struct {
 		Albums []*FullAlbum `json:"albums"`
 	}
-	err = json.NewDecoder(resp.Body).Decode(&a)
+
+	err := c.Get(spotifyURL, &a)
 	if err != nil {
 		return nil, err
 	}
+
 	return a.Albums, nil
 }
 
@@ -221,16 +209,12 @@ func (c *Client) GetAlbumTracksOpt(id ID, limit, offset int) (*SimpleTrackPage, 
 	if optional != "" {
 		spotifyURL = spotifyURL + "?" + optional
 	}
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
 
 	var result SimpleTrackPage
-	err = json.NewDecoder(resp.Body).Decode(&result)
+	err := c.Get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
+
 	return &result, nil
 }

--- a/artist.go
+++ b/artist.go
@@ -1,9 +1,7 @@
 package spotify
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -42,19 +40,13 @@ func GetArtist(id ID) (*FullArtist, error) {
 // GetArtist gets Spotify catalog information for a single artist, given its Spotify ID.
 func (c *Client) GetArtist(id ID) (*FullArtist, error) {
 	spotifyURL := fmt.Sprintf("%sartists/%s", baseAddress, id)
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+
 	var a FullArtist
-	err = json.NewDecoder(resp.Body).Decode(&a)
+	err := c.Get(spotifyURL, &a)
 	if err != nil {
 		return nil, err
 	}
+
 	return &a, nil
 }
 
@@ -70,21 +62,16 @@ func GetArtists(ids ...ID) ([]*FullArtist, error) {
 // in the result.
 func (c *Client) GetArtists(ids ...ID) ([]*FullArtist, error) {
 	spotifyURL := fmt.Sprintf("%sartists?ids=%s", baseAddress, strings.Join(toStringSlice(ids), ","))
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+	
 	var a struct {
 		Artists []*FullArtist
 	}
-	err = json.NewDecoder(resp.Body).Decode(&a)
+
+	err := c.Get(spotifyURL, &a)
 	if err != nil {
 		return nil, err
 	}
+
 	return a.Artists, nil
 }
 
@@ -98,22 +85,16 @@ func GetArtistsTopTracks(artistID ID, country string) ([]FullTrack, error) {
 // country is specified as an ISO 3166-1 alpha-2 country code.
 func (c *Client) GetArtistsTopTracks(artistID ID, country string) ([]FullTrack, error) {
 	spotifyURL := fmt.Sprintf("%sartists/%s/top-tracks?country=%s", baseAddress, artistID, country)
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+
 	var t struct {
 		Tracks []FullTrack `json:"tracks"`
 	}
 
-	err = json.NewDecoder(resp.Body).Decode(&t)
+	err := c.Get(spotifyURL, &t)
 	if err != nil {
 		return nil, err
 	}
+
 	return t.Tracks, nil
 }
 
@@ -128,21 +109,16 @@ func GetRelatedArtists(id ID) ([]FullArtist, error) {
 // related to the specified artist.
 func (c *Client) GetRelatedArtists(id ID) ([]FullArtist, error) {
 	spotifyURL := fmt.Sprintf("%sartists/%s/related-artists", baseAddress, id)
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+	
 	var a struct {
 		Artists []FullArtist `json:"artists"`
 	}
-	err = json.NewDecoder(resp.Body).Decode(&a)
+
+	err := c.Get(spotifyURL, &a)
 	if err != nil {
 		return nil, err
 	}
+
 	return a.Artists, nil
 }
 
@@ -194,19 +170,13 @@ func (c *Client) GetArtistAlbumsOpt(artistID ID, options *Options, t *AlbumType)
 	if query := values.Encode(); query != "" {
 		spotifyURL += "?" + query
 	}
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+	
 	var p SimpleAlbumPage
-	err = json.NewDecoder(resp.Body).Decode(&p)
+
+	err := c.Get(spotifyURL, &p)
 	if err != nil {
 		return nil, err
 	}
+
 	return &p, nil
 }

--- a/artist.go
+++ b/artist.go
@@ -42,7 +42,7 @@ func (c *Client) GetArtist(id ID) (*FullArtist, error) {
 	spotifyURL := fmt.Sprintf("%sartists/%s", baseAddress, id)
 
 	var a FullArtist
-	err := c.Get(spotifyURL, &a)
+	err := c.get(spotifyURL, &a)
 	if err != nil {
 		return nil, err
 	}
@@ -62,12 +62,12 @@ func GetArtists(ids ...ID) ([]*FullArtist, error) {
 // in the result.
 func (c *Client) GetArtists(ids ...ID) ([]*FullArtist, error) {
 	spotifyURL := fmt.Sprintf("%sartists?ids=%s", baseAddress, strings.Join(toStringSlice(ids), ","))
-	
+
 	var a struct {
 		Artists []*FullArtist
 	}
 
-	err := c.Get(spotifyURL, &a)
+	err := c.get(spotifyURL, &a)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (c *Client) GetArtistsTopTracks(artistID ID, country string) ([]FullTrack, 
 		Tracks []FullTrack `json:"tracks"`
 	}
 
-	err := c.Get(spotifyURL, &t)
+	err := c.get(spotifyURL, &t)
 	if err != nil {
 		return nil, err
 	}
@@ -109,12 +109,12 @@ func GetRelatedArtists(id ID) ([]FullArtist, error) {
 // related to the specified artist.
 func (c *Client) GetRelatedArtists(id ID) ([]FullArtist, error) {
 	spotifyURL := fmt.Sprintf("%sartists/%s/related-artists", baseAddress, id)
-	
+
 	var a struct {
 		Artists []FullArtist `json:"artists"`
 	}
 
-	err := c.Get(spotifyURL, &a)
+	err := c.get(spotifyURL, &a)
 	if err != nil {
 		return nil, err
 	}
@@ -170,10 +170,10 @@ func (c *Client) GetArtistAlbumsOpt(artistID ID, options *Options, t *AlbumType)
 	if query := values.Encode(); query != "" {
 		spotifyURL += "?" + query
 	}
-	
+
 	var p SimpleAlbumPage
 
-	err := c.Get(spotifyURL, &p)
+	err := c.get(spotifyURL, &p)
 	if err != nil {
 		return nil, err
 	}

--- a/audio_analysis.go
+++ b/audio_analysis.go
@@ -101,7 +101,7 @@ func (c *Client) GetAudioAnalysis(id ID) (*AudioAnalysis, error) {
 
 	temp := AudioAnalysis{}
 
-	err := c.Get(url, &temp)
+	err := c.get(url, &temp)
 	if err != nil {
 		return nil, err
 	}

--- a/audio_analysis.go
+++ b/audio_analysis.go
@@ -1,9 +1,7 @@
 package spotify
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 )
 
 // AudioAnalysis contains a detailed audio analysis for a single track
@@ -101,18 +99,9 @@ type AnalysisTrack struct {
 func (c *Client) GetAudioAnalysis(id ID) (*AudioAnalysis, error) {
 	url := fmt.Sprintf("%saudio-analysis/%s", baseAddress, id)
 
-	resp, err := c.http.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
-
 	temp := AudioAnalysis{}
-	err = json.NewDecoder(resp.Body).Decode(&temp)
+
+	err := c.Get(url, &temp)
 	if err != nil {
 		return nil, err
 	}

--- a/audio_features.go
+++ b/audio_features.go
@@ -115,7 +115,7 @@ func (c *Client) GetAudioFeatures(ids ...ID) ([]*AudioFeatures, error) {
 		F []*AudioFeatures `json:"audio_features"`
 	}{}
 
-	err := c.Get(url, &temp)
+	err := c.get(url, &temp)
 	if err != nil {
 		return nil, err
 	}

--- a/audio_features.go
+++ b/audio_features.go
@@ -1,9 +1,7 @@
 package spotify
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"strings"
 )
 
@@ -112,20 +110,15 @@ const (
 // This call requires authorization.
 func (c *Client) GetAudioFeatures(ids ...ID) ([]*AudioFeatures, error) {
 	url := fmt.Sprintf("%saudio-features?ids=%s", baseAddress, strings.Join(toStringSlice(ids), ","))
-	resp, err := c.http.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+
 	temp := struct {
 		F []*AudioFeatures `json:"audio_features"`
 	}{}
-	err = json.NewDecoder(resp.Body).Decode(&temp)
+
+	err := c.Get(url, &temp)
 	if err != nil {
 		return nil, err
 	}
+
 	return temp.F, nil
 }

--- a/category.go
+++ b/category.go
@@ -42,8 +42,8 @@ func (c *Client) GetCategoryOpt(id, country, locale string) (Category, error) {
 	if query := values.Encode(); query != "" {
 		spotifyURL += "?" + query
 	}
-	
-	err := c.Get(spotifyURL, &cat)
+
+	err := c.get(spotifyURL, &cat)
 	if err != nil {
 		return cat, err
 	}
@@ -83,12 +83,12 @@ func (c *Client) GetCategoryPlaylistsOpt(catID string, opt *Options) (*SimplePla
 			spotifyURL += "?" + query
 		}
 	}
-	
+
 	wrapper := struct {
 		Playlists SimplePlaylistPage `json:"playlists"`
 	}{}
 
-	err := c.Get(spotifyURL, &wrapper)
+	err := c.get(spotifyURL, &wrapper)
 	if err != nil {
 		return nil, err
 	}
@@ -130,12 +130,12 @@ func (c *Client) GetCategoriesOpt(opt *Options, locale string) (*CategoryPage, e
 	if query := values.Encode(); query != "" {
 		spotifyURL += "?" + query
 	}
-	
+
 	wrapper := struct {
 		Categories CategoryPage `json:"categories"`
 	}{}
 
-	err := c.Get(spotifyURL, &wrapper)
+	err := c.get(spotifyURL, &wrapper)
 	if err != nil {
 		return nil, err
 	}

--- a/category.go
+++ b/category.go
@@ -1,9 +1,7 @@
 package spotify
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strconv"
 )
@@ -44,15 +42,12 @@ func (c *Client) GetCategoryOpt(id, country, locale string) (Category, error) {
 	if query := values.Encode(); query != "" {
 		spotifyURL += "?" + query
 	}
-	resp, err := c.http.Get(spotifyURL)
+	
+	err := c.Get(spotifyURL, &cat)
 	if err != nil {
 		return cat, err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return cat, decodeError(resp.Body)
-	}
-	err = json.NewDecoder(resp.Body).Decode(&cat)
+
 	return cat, err
 }
 
@@ -88,21 +83,16 @@ func (c *Client) GetCategoryPlaylistsOpt(catID string, opt *Options) (*SimplePla
 			spotifyURL += "?" + query
 		}
 	}
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+	
 	wrapper := struct {
 		Playlists SimplePlaylistPage `json:"playlists"`
 	}{}
-	err = json.NewDecoder(resp.Body).Decode(&wrapper)
+
+	err := c.Get(spotifyURL, &wrapper)
 	if err != nil {
 		return nil, err
 	}
+
 	return &wrapper.Playlists, nil
 }
 
@@ -140,20 +130,15 @@ func (c *Client) GetCategoriesOpt(opt *Options, locale string) (*CategoryPage, e
 	if query := values.Encode(); query != "" {
 		spotifyURL += "?" + query
 	}
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+	
 	wrapper := struct {
 		Categories CategoryPage `json:"categories"`
 	}{}
-	err = json.NewDecoder(resp.Body).Decode(&wrapper)
+
+	err := c.Get(spotifyURL, &wrapper)
 	if err != nil {
 		return nil, err
 	}
+
 	return &wrapper.Categories, nil
 }

--- a/library.go
+++ b/library.go
@@ -54,13 +54,9 @@ func (c *Client) modifyLibraryTracks(add bool, ids ...ID) error {
 	if err != nil {
 		return err
 	}
-	resp, err := c.http.Do(req)
+	err = c.execute(req)
 	if err != nil {
 		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return decodeError(c, resp)
 	}
 	return nil
 }

--- a/library.go
+++ b/library.go
@@ -14,10 +14,10 @@ func (c *Client) UserHasTracks(ids ...ID) ([]bool, error) {
 		return nil, errors.New("spotify: UserHasTracks supports 1 to 50 IDs per call")
 	}
 	spotifyURL := fmt.Sprintf("%sme/tracks/contains?ids=%s", baseAddress, strings.Join(toStringSlice(ids), ","))
-	
+
 	var result []bool
 
-	err := c.Get(spotifyURL, &result)
+	err := c.get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/library.go
+++ b/library.go
@@ -1,7 +1,6 @@
 package spotify
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -15,16 +14,14 @@ func (c *Client) UserHasTracks(ids ...ID) ([]bool, error) {
 		return nil, errors.New("spotify: UserHasTracks supports 1 to 50 IDs per call")
 	}
 	spotifyURL := fmt.Sprintf("%sme/tracks/contains?ids=%s", baseAddress, strings.Join(toStringSlice(ids), ","))
-	resp, err := c.http.Get(spotifyURL)
+	
+	var result []bool
+
+	err := c.Get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
-	var result []bool
-	err = json.NewDecoder(resp.Body).Decode(&result)
+
 	return result, err
 }
 
@@ -63,7 +60,7 @@ func (c *Client) modifyLibraryTracks(add bool, ids ...ID) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return decodeError(resp.Body)
+		return decodeError(c, resp)
 	}
 	return nil
 }

--- a/page.go
+++ b/page.go
@@ -88,7 +88,7 @@ type CategoryPage struct {
 
 // getPage GETs the data at the specified URL and unmarshals it into page.
 func (c *Client) getPage(url string, page interface{}) error {
-	err := c.Get(url, page)
+	err := c.get(url, page)
 	if err != nil {
 		return err
 	}

--- a/page.go
+++ b/page.go
@@ -1,7 +1,6 @@
 package spotify
 
 import (
-	"encoding/json"
 	"errors"
 )
 
@@ -89,10 +88,10 @@ type CategoryPage struct {
 
 // getPage GETs the data at the specified URL and unmarshals it into page.
 func (c *Client) getPage(url string, page interface{}) error {
-	resp, err := c.http.Get(url)
+	err := c.Get(url, page)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
-	return json.NewDecoder(resp.Body).Decode(page)
+
+	return nil
 }

--- a/page.go
+++ b/page.go
@@ -85,13 +85,3 @@ type CategoryPage struct {
 	basePage
 	Categories []Category `json:"items"`
 }
-
-// getPage GETs the data at the specified URL and unmarshals it into page.
-func (c *Client) getPage(url string, page interface{}) error {
-	err := c.get(url, page)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}

--- a/player.go
+++ b/player.go
@@ -92,18 +92,11 @@ type PlayOptions struct {
 //
 // Requires the ScopeUserReadPlaybackState scope in order to read information
 func (c *Client) PlayerDevices() ([]PlayerDevice, error) {
-	resp, err := c.http.Get(baseAddress + "me/player/devices")
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
 	var result struct {
 		PlayerDevices []PlayerDevice `json:"devices"`
 	}
-	err = json.NewDecoder(resp.Body).Decode(&result)
+
+	err := c.Get(baseAddress + "me/player/devices", &result)
 	if err != nil {
 		return nil, err
 	}
@@ -132,19 +125,14 @@ func (c *Client) PlayerStateOpt(opt *Options) (*PlayerState, error) {
 			spotifyURL += "?" + params
 		}
 	}
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+	
 	var result PlayerState
-	err = json.NewDecoder(resp.Body).Decode(&result)
+
+	err := c.Get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
+
 	return &result, nil
 }
 
@@ -170,19 +158,14 @@ func (c *Client) PlayerCurrentlyPlayingOpt(opt *Options) (*CurrentlyPlaying, err
 			spotifyURL += "?" + params
 		}
 	}
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+	
 	var result CurrentlyPlaying
-	err = json.NewDecoder(resp.Body).Decode(&result)
+
+	err := c.Get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
+
 	return &result, nil
 }
 
@@ -213,13 +196,11 @@ func (c *Client) TransferPlayback(deviceID ID, play bool) error {
 	if err != nil {
 		return err
 	}
-	resp, err := c.http.Do(req)
+	err = c.Execute(req)
 	if err != nil {
 		return err
 	}
-	if resp.StatusCode != http.StatusNoContent {
-		return decodeError(resp.Body)
-	}
+
 	return nil
 }
 
@@ -254,12 +235,9 @@ func (c *Client) PlayOpt(opt *PlayOptions) error {
 	if err != nil {
 		return err
 	}
-	resp, err := c.http.Do(req)
+	err = c.Execute(req)
 	if err != nil {
 		return err
-	}
-	if resp.StatusCode != http.StatusNoContent {
-		return decodeError(resp.Body)
 	}
 	return nil
 }
@@ -291,12 +269,9 @@ func (c *Client) PauseOpt(opt *PlayOptions) error {
 	if err != nil {
 		return err
 	}
-	resp, err := c.http.Do(req)
+	err = c.Execute(req)
 	if err != nil {
 		return err
-	}
-	if resp.StatusCode != http.StatusNoContent {
-		return decodeError(resp.Body)
 	}
 	return nil
 }
@@ -328,12 +303,9 @@ func (c *Client) NextOpt(opt *PlayOptions) error {
 	if err != nil {
 		return err
 	}
-	resp, err := c.http.Do(req)
+	err = c.Execute(req)
 	if err != nil {
 		return err
-	}
-	if resp.StatusCode != http.StatusNoContent {
-		return decodeError(resp.Body)
 	}
 	return nil
 }
@@ -365,12 +337,9 @@ func (c *Client) PreviousOpt(opt *PlayOptions) error {
 	if err != nil {
 		return err
 	}
-	resp, err := c.http.Do(req)
+	err = c.Execute(req)
 	if err != nil {
 		return err
-	}
-	if resp.StatusCode != http.StatusNoContent {
-		return decodeError(resp.Body)
 	}
 	return nil
 }
@@ -483,12 +452,9 @@ func (c *Client) playerFuncWithOpt(urlSuffix string, values url.Values, opt *Pla
 	if err != nil {
 		return err
 	}
-	resp, err := c.http.Do(req)
+	err = c.Execute(req)
 	if err != nil {
 		return err
-	}
-	if resp.StatusCode != http.StatusNoContent {
-		return decodeError(resp.Body)
 	}
 	return nil
 }

--- a/player.go
+++ b/player.go
@@ -96,7 +96,7 @@ func (c *Client) PlayerDevices() ([]PlayerDevice, error) {
 		PlayerDevices []PlayerDevice `json:"devices"`
 	}
 
-	err := c.Get(baseAddress + "me/player/devices", &result)
+	err := c.get(baseAddress+"me/player/devices", &result)
 	if err != nil {
 		return nil, err
 	}
@@ -125,10 +125,10 @@ func (c *Client) PlayerStateOpt(opt *Options) (*PlayerState, error) {
 			spotifyURL += "?" + params
 		}
 	}
-	
+
 	var result PlayerState
 
-	err := c.Get(spotifyURL, &result)
+	err := c.get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -158,10 +158,10 @@ func (c *Client) PlayerCurrentlyPlayingOpt(opt *Options) (*CurrentlyPlaying, err
 			spotifyURL += "?" + params
 		}
 	}
-	
+
 	var result CurrentlyPlaying
 
-	err := c.Get(spotifyURL, &result)
+	err := c.get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (c *Client) TransferPlayback(deviceID ID, play bool) error {
 	if err != nil {
 		return err
 	}
-	err = c.Execute(req)
+	err = c.execute(req)
 	if err != nil {
 		return err
 	}
@@ -235,7 +235,7 @@ func (c *Client) PlayOpt(opt *PlayOptions) error {
 	if err != nil {
 		return err
 	}
-	err = c.Execute(req)
+	err = c.execute(req)
 	if err != nil {
 		return err
 	}
@@ -269,7 +269,7 @@ func (c *Client) PauseOpt(opt *PlayOptions) error {
 	if err != nil {
 		return err
 	}
-	err = c.Execute(req)
+	err = c.execute(req)
 	if err != nil {
 		return err
 	}
@@ -303,7 +303,7 @@ func (c *Client) NextOpt(opt *PlayOptions) error {
 	if err != nil {
 		return err
 	}
-	err = c.Execute(req)
+	err = c.execute(req)
 	if err != nil {
 		return err
 	}
@@ -337,7 +337,7 @@ func (c *Client) PreviousOpt(opt *PlayOptions) error {
 	if err != nil {
 		return err
 	}
-	err = c.Execute(req)
+	err = c.execute(req)
 	if err != nil {
 		return err
 	}
@@ -452,7 +452,7 @@ func (c *Client) playerFuncWithOpt(urlSuffix string, values url.Values, opt *Pla
 	if err != nil {
 		return err
 	}
-	err = c.Execute(req)
+	err = c.execute(req)
 	if err != nil {
 		return err
 	}

--- a/playlist.go
+++ b/playlist.go
@@ -99,13 +99,13 @@ func (c *Client) FeaturedPlaylistsOpt(opt *PlaylistOptions) (message string, pla
 			spotifyURL += "?" + params
 		}
 	}
-	
+
 	var result struct {
 		Playlists SimplePlaylistPage `json:"playlists"`
 		Message   string             `json:"message"`
 	}
 
-	err := c.Get(spotifyURL, &result)
+	err := c.get(spotifyURL, &result)
 	if err != nil {
 		return "", nil, err
 	}
@@ -135,7 +135,7 @@ func (c *Client) FollowPlaylist(owner ID, playlist ID, public bool) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	err = c.Execute(req)
+	err = c.execute(req)
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func (c *Client) UnfollowPlaylist(owner, playlist ID) error {
 	if err != nil {
 		return err
 	}
-	err = c.Execute(req)
+	err = c.execute(req)
 	if err != nil {
 		return err
 	}
@@ -193,10 +193,10 @@ func (c *Client) GetPlaylistsForUserOpt(userID string, opt *Options) (*SimplePla
 			spotifyURL += "?" + params
 		}
 	}
-	
+
 	var result SimplePlaylistPage
 
-	err := c.Get(spotifyURL, &result)
+	err := c.get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -234,10 +234,10 @@ func (c *Client) GetPlaylistOpt(userID string, playlistID ID, fields string) (*F
 	if fields != "" {
 		spotifyURL += "?fields=" + url.QueryEscape(fields)
 	}
-	
+
 	var playlist FullPlaylist
 
-	err := c.Get(spotifyURL, &playlist)
+	err := c.get(spotifyURL, &playlist)
 	if err != nil {
 		return nil, err
 	}
@@ -289,10 +289,10 @@ func (c *Client) GetPlaylistTracksOpt(userID string, playlistID ID,
 	if params := v.Encode(); params != "" {
 		spotifyURL += "?" + params
 	}
-	
+
 	var result PlaylistTrackPage
 
-	err := c.Get(spotifyURL, &result)
+	err := c.get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +331,7 @@ func (c *Client) CreatePlaylistForUser(userID, playlistName string, public bool)
 	req.Header.Set("Content-Type", "application/json")
 
 	var p FullPlaylist
-	err = c.ExecuteOpt(req, http.StatusCreated, &p)
+	err = c.executeOpt(req, http.StatusCreated, &p)
 	if err != nil {
 		return nil, err
 	}
@@ -381,7 +381,7 @@ func (c *Client) modifyPlaylist(userID string, playlistID ID, newName string, pu
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	err = c.Execute(req)
+	err = c.execute(req)
 	if err != nil {
 		return err
 	}
@@ -410,7 +410,7 @@ func (c *Client) AddTracksToPlaylist(userID string, playlistID ID,
 	body := struct {
 		SnapshotID string `json:"snapshot_id"`
 	}{}
-	err = c.ExecuteOpt(req, http.StatusCreated, &body)
+	err = c.executeOpt(req, http.StatusCreated, &body)
 	if err != nil {
 		return "", err
 	}
@@ -498,7 +498,7 @@ func (c *Client) removeTracksFromPlaylist(userID string, playlistID ID,
 		SnapshotID string `json:"snapshot_id"`
 	}{}
 
-	err = c.ExecuteOpt(req, 0, &result)
+	err = c.executeOpt(req, 0, &result)
 	if err != nil {
 		return "", nil
 	}
@@ -527,7 +527,7 @@ func (c *Client) ReplacePlaylistTracks(userID string, playlistID ID, trackIDs ..
 	if err != nil {
 		return err
 	}
-	err = c.Execute(req)
+	err = c.execute(req)
 	if err != nil {
 		return err
 	}
@@ -545,10 +545,10 @@ func (c *Client) ReplacePlaylistTracks(userID string, playlistID ID, trackIDs ..
 func (c *Client) UserFollowsPlaylist(ownerID string, playlistID ID, userIDs ...string) ([]bool, error) {
 	spotifyURL := fmt.Sprintf("%susers/%s/playlists/%s/followers/contains?ids=%s",
 		baseAddress, ownerID, playlistID, strings.Join(userIDs, ","))
-	
+
 	follows := make([]bool, len(userIDs))
 
-	err := c.Get(spotifyURL, &follows)
+	err := c.get(spotifyURL, &follows)
 	if err != nil {
 		return nil, err
 	}
@@ -609,7 +609,7 @@ func (c *Client) ReorderPlaylistTracks(userID string, playlistID ID, opt Playlis
 	result := struct {
 		SnapshotID string `json:"snapshot_id"`
 	}{}
-	err = c.ExecuteOpt(req, 0, &result)
+	err = c.executeOpt(req, 0, &result)
 	if err != nil {
 		return "", err
 	}

--- a/playlist.go
+++ b/playlist.go
@@ -527,7 +527,7 @@ func (c *Client) ReplacePlaylistTracks(userID string, playlistID ID, trackIDs ..
 	if err != nil {
 		return err
 	}
-	err = c.execute(req)
+	err = c.executeOpt(req, http.StatusCreated, nil)
 	if err != nil {
 		return err
 	}

--- a/recommendation.go
+++ b/recommendation.go
@@ -95,9 +95,9 @@ func (c *Client) GetRecommendations(seeds Seeds, trackAttributes *TrackAttribute
 	}
 
 	spotifyURL := baseAddress + "recommendations?" + v.Encode()
-	
+
 	var recommendations Recommendations
-	err := c.Get(spotifyURL, &recommendations)
+	err := c.get(spotifyURL, &recommendations)
 	if err != nil {
 		return nil, err
 	}
@@ -109,10 +109,10 @@ func (c *Client) GetRecommendations(seeds Seeds, trackAttributes *TrackAttribute
 // recommendations.
 func (c *Client) GetAvailableGenreSeeds() ([]string, error) {
 	spotifyURL := baseAddress + "recommendations/available-genre-seeds"
-	
+
 	genreSeeds := make(map[string][]string)
 
-	err := c.Get(spotifyURL, &genreSeeds)
+	err := c.get(spotifyURL, &genreSeeds)
 	if err != nil {
 		return nil, err
 	}

--- a/recommendation.go
+++ b/recommendation.go
@@ -1,9 +1,7 @@
 package spotify
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -97,21 +95,13 @@ func (c *Client) GetRecommendations(seeds Seeds, trackAttributes *TrackAttribute
 	}
 
 	spotifyURL := baseAddress + "recommendations?" + v.Encode()
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
-
+	
 	var recommendations Recommendations
-	err = json.NewDecoder(resp.Body).Decode(&recommendations)
+	err := c.Get(spotifyURL, &recommendations)
 	if err != nil {
 		return nil, err
 	}
+
 	return &recommendations, err
 }
 
@@ -119,19 +109,13 @@ func (c *Client) GetRecommendations(seeds Seeds, trackAttributes *TrackAttribute
 // recommendations.
 func (c *Client) GetAvailableGenreSeeds() ([]string, error) {
 	spotifyURL := baseAddress + "recommendations/available-genre-seeds"
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+	
 	genreSeeds := make(map[string][]string)
-	err = json.NewDecoder(resp.Body).Decode(&genreSeeds)
+
+	err := c.Get(spotifyURL, &genreSeeds)
 	if err != nil {
 		return nil, err
 	}
+
 	return genreSeeds["genres"], nil
 }

--- a/search.go
+++ b/search.go
@@ -1,8 +1,6 @@
 package spotify
 
 import (
-	"encoding/json"
-	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -142,22 +140,16 @@ func (c *Client) SearchOpt(query string, t SearchType, opt *Options) (*SearchRes
 			v.Set("offset", strconv.Itoa(*opt.Offset))
 		}
 	}
-	spotifyURL := baseAddress + "search?" + v.Encode()
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+	spotifyURL := baseAddress + "search?" + v.Encode()
 
 	var result SearchResult
-	err = json.NewDecoder(resp.Body).Decode(&result)
+
+	err := c.Get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
+
 	return &result, err
 }
 

--- a/search.go
+++ b/search.go
@@ -158,7 +158,7 @@ func (c *Client) NextArtistResults(s *SearchResult) error {
 	if s.Artists == nil || s.Artists.Next == "" {
 		return ErrNoMorePages
 	}
-	return c.getPage(s.Artists.Next, s)
+	return c.get(s.Artists.Next, s)
 }
 
 // PreviousArtistResults loads the previous page of artists into the specified search result.
@@ -166,7 +166,7 @@ func (c *Client) PreviousArtistResults(s *SearchResult) error {
 	if s.Artists == nil || s.Artists.Previous == "" {
 		return ErrNoMorePages
 	}
-	return c.getPage(s.Artists.Previous, s)
+	return c.get(s.Artists.Previous, s)
 }
 
 // NextAlbumResults loads the next page of albums into the specified search result.
@@ -174,7 +174,7 @@ func (c *Client) NextAlbumResults(s *SearchResult) error {
 	if s.Albums == nil || s.Albums.Next == "" {
 		return ErrNoMorePages
 	}
-	return c.getPage(s.Albums.Next, s)
+	return c.get(s.Albums.Next, s)
 }
 
 // PreviousAlbumResults loads the previous page of albums into the specified search result.
@@ -182,7 +182,7 @@ func (c *Client) PreviousAlbumResults(s *SearchResult) error {
 	if s.Albums == nil || s.Albums.Previous == "" {
 		return ErrNoMorePages
 	}
-	return c.getPage(s.Albums.Previous, s)
+	return c.get(s.Albums.Previous, s)
 }
 
 // NextPlaylistResults loads the next page of playlists into the specified search result.
@@ -190,7 +190,7 @@ func (c *Client) NextPlaylistResults(s *SearchResult) error {
 	if s.Playlists == nil || s.Playlists.Next == "" {
 		return ErrNoMorePages
 	}
-	return c.getPage(s.Playlists.Next, s)
+	return c.get(s.Playlists.Next, s)
 }
 
 // PreviousPlaylistResults loads the previous page of playlists into the specified search result.
@@ -198,7 +198,7 @@ func (c *Client) PreviousPlaylistResults(s *SearchResult) error {
 	if s.Playlists == nil || s.Playlists.Previous == "" {
 		return ErrNoMorePages
 	}
-	return c.getPage(s.Playlists.Previous, s)
+	return c.get(s.Playlists.Previous, s)
 }
 
 // PreviousTrackResults loads the previous page of tracks into the specified search result.
@@ -206,7 +206,7 @@ func (c *Client) PreviousTrackResults(s *SearchResult) error {
 	if s.Tracks == nil || s.Tracks.Previous == "" {
 		return ErrNoMorePages
 	}
-	return c.getPage(s.Tracks.Previous, s)
+	return c.get(s.Tracks.Previous, s)
 }
 
 // NextTrackResults loads the next page of tracks into the specified search result.
@@ -214,5 +214,5 @@ func (c *Client) NextTrackResults(s *SearchResult) error {
 	if s.Tracks == nil || s.Tracks.Next == "" {
 		return ErrNoMorePages
 	}
-	return c.getPage(s.Tracks.Next, s)
+	return c.get(s.Tracks.Next, s)
 }

--- a/search.go
+++ b/search.go
@@ -145,7 +145,7 @@ func (c *Client) SearchOpt(query string, t SearchType, opt *Options) (*SearchRes
 
 	var result SearchResult
 
-	err := c.Get(spotifyURL, &result)
+	err := c.get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/spotify.go
+++ b/spotify.go
@@ -125,7 +125,7 @@ func (c *Client) decodeError(resp *http.Response) error {
 	}
 
 	if len(responseBody) == 0 {
-		return fmt.Errorf("spotify: there was an HTTP error (%d '%s') but the body was empty", resp.StatusCode, http.StatusText(resp.StatusCode))
+		return fmt.Errorf("spotify: HTTP %d: %s (body empty)", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 
 	buf := bytes.NewBuffer(responseBody)
@@ -143,7 +143,7 @@ func (c *Client) decodeError(resp *http.Response) error {
 		if retrySecondsRaw != "" {
 			retrySeconds, err := strconv.ParseInt(retrySecondsRaw, 10, 32)
 			if err != nil {
-				return fmt.Errorf("could not parse retry seconds: %s", retrySecondsRaw)
+				return fmt.Errorf("spotify: could not parse retry seconds: %s", retrySecondsRaw)
 			}
 
 			if retrySeconds == 0 {
@@ -159,7 +159,7 @@ func (c *Client) decodeError(resp *http.Response) error {
 		// some of the arguments directly in the HTTP query and the URL ends-up
 		// being too long.
 
-		e.E.Message = fmt.Sprintf("spotify: there was an HTTP error (%d '%s') but we received an empty error", resp.StatusCode, http.StatusText(resp.StatusCode))
+		e.E.Message = fmt.Sprintf("spotify: unexpected HTTP %d: %s (empty error)", resp.StatusCode, http.StatusText(resp.StatusCode))
 	}
 
 	return e.E

--- a/spotify.go
+++ b/spotify.go
@@ -180,7 +180,7 @@ func (c *Client) SetAutoRetry(flag bool) {
 	c.autoRetry = flag
 }
 
-func (c *Client) ExecuteOpt(req *http.Request, needsStatus int, result interface{}) error {
+func (c *Client) executeOpt(req *http.Request, needsStatus int, result interface{}) error {
 	for {
 		resp, err := c.http.Do(req)
 		if err != nil {
@@ -209,11 +209,11 @@ func (c *Client) ExecuteOpt(req *http.Request, needsStatus int, result interface
 	return nil
 }
 
-func (c *Client) Execute(req *http.Request) error {
-	return c.ExecuteOpt(req, 0, nil)
+func (c *Client) execute(req *http.Request) error {
+	return c.executeOpt(req, 0, nil)
 }
 
-func (c *Client) Get(url string, result interface{}) error {
+func (c *Client) get(url string, result interface{}) error {
 	for {
 		resp, err := c.http.Get(url)
 		if err != nil {

--- a/spotify.go
+++ b/spotify.go
@@ -118,7 +118,7 @@ func (e Error) Error() string {
 }
 
 // decodeError decodes an Error from an io.Reader.
-func decodeError(c *Client, resp *http.Response) error {
+func (c *Client) decodeError(resp *http.Response) error {
 	responseBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
@@ -197,7 +197,7 @@ func (c *Client) executeOpt(req *http.Request, needsStatus int, result interface
 			time.Sleep(c.retryDuration)
 			continue
 		} else if resp.StatusCode != http.StatusOK && (needsStatus == 0 || resp.StatusCode != needsStatus) {
-			errorMessage := decodeError(c, resp)
+			errorMessage := c.decodeError(resp)
 			return errorMessage
 		}
 
@@ -230,7 +230,7 @@ func (c *Client) get(url string, result interface{}) error {
 			time.Sleep(c.retryDuration)
 			continue
 		} else if resp.StatusCode != http.StatusOK {
-			errorMessage := decodeError(c, resp)
+			errorMessage := c.decodeError(resp)
 			return errorMessage
 		}
 
@@ -286,7 +286,7 @@ func (c *Client) NewReleasesOpt(opt *Options) (albums *SimpleAlbumPage, err erro
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(c, resp)
+		return nil, c.decodeError(resp)
 	}
 	var objmap map[string]*json.RawMessage
 	err = json.NewDecoder(resp.Body).Decode(&objmap)

--- a/spotify.go
+++ b/spotify.go
@@ -172,12 +172,8 @@ func (c *Client) decodeError(resp *http.Response) error {
 type Client struct {
 	http *http.Client
 
-	autoRetry     bool
+	AutoRetry     bool
 	retryDuration time.Duration
-}
-
-func (c *Client) SetAutoRetry(flag bool) {
-	c.autoRetry = flag
 }
 
 // executeOpt executes a non-GET request. `needsStatus` describes another code
@@ -193,7 +189,7 @@ func (c *Client) executeOpt(req *http.Request, needsStatus int, result interface
 
 		defer resp.Body.Close()
 
-		if resp.StatusCode == rateLimitExceededStatusCode && c.autoRetry {
+		if resp.StatusCode == rateLimitExceededStatusCode && c.AutoRetry {
 			time.Sleep(c.retryDuration)
 			continue
 		} else if resp.StatusCode != http.StatusOK && (needsStatus == 0 || resp.StatusCode != needsStatus) {
@@ -226,7 +222,7 @@ func (c *Client) get(url string, result interface{}) error {
 
 		defer resp.Body.Close()
 
-		if resp.StatusCode == rateLimitExceededStatusCode && c.autoRetry {
+		if resp.StatusCode == rateLimitExceededStatusCode && c.AutoRetry {
 			time.Sleep(c.retryDuration)
 			continue
 		} else if resp.StatusCode != http.StatusOK {

--- a/spotify.go
+++ b/spotify.go
@@ -180,6 +180,10 @@ func (c *Client) SetAutoRetry(flag bool) {
 	c.autoRetry = flag
 }
 
+// executeOpt executes a non-GET request. `needsStatus` describes another code
+// that can represent success. Note that in all current usages of this function,
+// we need to still allow a 200 even if we'd also like to check for a second
+// success code.
 func (c *Client) executeOpt(req *http.Request, needsStatus int, result interface{}) error {
 	for {
 		resp, err := c.http.Do(req)
@@ -192,7 +196,7 @@ func (c *Client) executeOpt(req *http.Request, needsStatus int, result interface
 		if resp.StatusCode == rateLimitExceededStatusCode && c.autoRetry {
 			time.Sleep(c.retryDuration)
 			continue
-		} else if resp.StatusCode != http.StatusOK || needsStatus != 0 && resp.StatusCode != needsStatus {
+		} else if resp.StatusCode != http.StatusOK && (needsStatus == 0 || resp.StatusCode != needsStatus) {
 			errorMessage := decodeError(c, resp)
 			return errorMessage
 		}

--- a/spotify.go
+++ b/spotify.go
@@ -3,16 +3,16 @@
 package spotify
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
-	"bytes"
-	"fmt"
 	"time"
 )
 
@@ -30,11 +30,11 @@ const (
 	// this format.
 	TimestampLayout = "2006-01-02T15:04:05Z"
 
-	// rateLimitExceededErrorMessage is the message we'll receive if we were 
+	// rateLimitExceededErrorMessage is the message we'll receive if we were
 	// told to wait a bit until our next request.
 	rateLimitExceededErrorMessage = "API rate limit exceeded"
 
-	// defaultRetryDurationS helps us fix an apparent server bug whereby we will 
+	// defaultRetryDurationS helps us fix an apparent server bug whereby we will
 	// be told to retry but not be given a wait-interval.
 	defaultRetryDuration = time.Second * 5
 )
@@ -157,10 +157,10 @@ func decodeError(c *Client, resp *http.Response) error {
 			}
 		}
 	} else if e.E.Error() == "" {
-		// Some errors will result in there being a useful status-code but an 
-		// empty message, which will confuse the user (who only has access to 
-		// the message and not the code). An example of this is when we send 
-		// some of the arguments directly in the HTTP query and the URL ends-up 
+		// Some errors will result in there being a useful status-code but an
+		// empty message, which will confuse the user (who only has access to
+		// the message and not the code). An example of this is when we send
+		// some of the arguments directly in the HTTP query and the URL ends-up
 		// being too long.
 
 		e.E.Message = "http: " + http.StatusText(resp.StatusCode)
@@ -174,7 +174,7 @@ func decodeError(c *Client, resp *http.Response) error {
 // `Authenticator.NewClient` method.  If you don't need to
 // authenticate, you can use `DefaultClient`.
 type Client struct {
-	http *http.Client
+	http          *http.Client
 	retryDuration time.Duration
 }
 
@@ -280,9 +280,6 @@ func (c *Client) NewReleasesOpt(opt *Options) (albums *SimpleAlbumPage, err erro
 			spotifyURL += "?" + params
 		}
 	}
-
-// TODO(dustin): Doesn't currently support retrying because this is more complicate than all of the other Get() references that we've already replaced with our standard calls. This would require us to duplicate the functionality out of the Get() function. However, we suspect that this can be simplified, though we'll need a second opinion before we make any changes.
-
 	resp, err := c.http.Get(spotifyURL)
 	if err != nil {
 		return nil, err

--- a/spotify.go
+++ b/spotify.go
@@ -276,16 +276,9 @@ func (c *Client) NewReleasesOpt(opt *Options) (albums *SimpleAlbumPage, err erro
 			spotifyURL += "?" + params
 		}
 	}
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, c.decodeError(resp)
-	}
+
 	var objmap map[string]*json.RawMessage
-	err = json.NewDecoder(resp.Body).Decode(&objmap)
+	err = c.get(spotifyURL, &objmap)
 	if err != nil {
 		return nil, err
 	}
@@ -295,6 +288,7 @@ func (c *Client) NewReleasesOpt(opt *Options) (albums *SimpleAlbumPage, err erro
 	if err != nil {
 		return nil, err
 	}
+
 	return &result, nil
 }
 

--- a/track.go
+++ b/track.go
@@ -1,9 +1,7 @@
 package spotify
 
 import (
-	"encoding/json"
 	"errors"
-	"net/http"
 	"strings"
 	"time"
 )
@@ -87,19 +85,14 @@ func GetTrack(id ID) (*FullTrack, error) {
 // a single track identified by its unique Spotify ID.
 func (c *Client) GetTrack(id ID) (*FullTrack, error) {
 	spotifyURL := baseAddress + "tracks/" + string(id)
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+	
 	var t FullTrack
-	err = json.NewDecoder(resp.Body).Decode(&t)
+
+	err := c.Get(spotifyURL, &t)
 	if err != nil {
 		return nil, err
 	}
+
 	return &t, nil
 }
 
@@ -118,21 +111,15 @@ func (c *Client) GetTracks(ids ...ID) ([]*FullTrack, error) {
 		return nil, errors.New("spotify: FindTracks supports up to 50 tracks")
 	}
 	spotifyURL := baseAddress + "tracks?ids=" + strings.Join(toStringSlice(ids), ",")
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
-
+	
 	var t struct {
 		Tracks []*FullTrack `jsosn:"tracks"`
 	}
-	err = json.NewDecoder(resp.Body).Decode(&t)
+
+	err := c.Get(spotifyURL, &t)
 	if err != nil {
-		return nil, errors.New("spotify:  couldn't decode tracks")
+		return nil, err
 	}
+
 	return t.Tracks, nil
 }

--- a/track.go
+++ b/track.go
@@ -85,10 +85,10 @@ func GetTrack(id ID) (*FullTrack, error) {
 // a single track identified by its unique Spotify ID.
 func (c *Client) GetTrack(id ID) (*FullTrack, error) {
 	spotifyURL := baseAddress + "tracks/" + string(id)
-	
+
 	var t FullTrack
 
-	err := c.Get(spotifyURL, &t)
+	err := c.get(spotifyURL, &t)
 	if err != nil {
 		return nil, err
 	}
@@ -111,12 +111,12 @@ func (c *Client) GetTracks(ids ...ID) ([]*FullTrack, error) {
 		return nil, errors.New("spotify: FindTracks supports up to 50 tracks")
 	}
 	spotifyURL := baseAddress + "tracks?ids=" + strings.Join(toStringSlice(ids), ",")
-	
+
 	var t struct {
 		Tracks []*FullTrack `jsosn:"tracks"`
 	}
 
-	err := c.Get(spotifyURL, &t)
+	err := c.get(spotifyURL, &t)
 	if err != nil {
 		return nil, err
 	}

--- a/user.go
+++ b/user.go
@@ -217,13 +217,9 @@ func (c *Client) modifyFollowers(usertype string, follow bool, ids ...ID) error 
 	if err != nil {
 		return err
 	}
-	resp, err := c.http.Do(req)
+	err = c.execute(req)
 	if err != nil {
 		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusNoContent {
-		return decodeError(c, resp)
 	}
 	return nil
 }

--- a/user.go
+++ b/user.go
@@ -66,7 +66,7 @@ func (c *Client) GetUsersPublicProfile(userID ID) (*User, error) {
 
 	var user User
 
-	err := c.Get(spotifyURL, &user)
+	err := c.get(spotifyURL, &user)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +89,7 @@ func (c *Client) GetUsersPublicProfile(userID ID) (*User, error) {
 func (c *Client) CurrentUser() (*PrivateUser, error) {
 	var result PrivateUser
 
-	err := c.Get(baseAddress + "me", &result)
+	err := c.get(baseAddress+"me", &result)
 	if err != nil {
 		return nil, err
 	}
@@ -122,10 +122,10 @@ func (c *Client) CurrentUsersTracksOpt(opt *Options) (*SavedTrackPage, error) {
 			spotifyURL += "?" + params
 		}
 	}
-	
+
 	var result SavedTrackPage
 
-	err := c.Get(spotifyURL, &result)
+	err := c.get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func (c *Client) CurrentUserFollows(t string, ids ...ID) ([]bool, error) {
 
 	var result []bool
 
-	err := c.Get(spotifyURL, &result)
+	err := c.get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -254,12 +254,12 @@ func (c *Client) CurrentUsersFollowedArtistsOpt(limit int, after string) (*FullA
 	if params := v.Encode(); params != "" {
 		spotifyURL += "?" + params
 	}
-	
+
 	var result struct {
 		A FullArtistCursorPage `json:"artists"`
 	}
 
-	err := c.Get(spotifyURL, &result)
+	err := c.get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -292,10 +292,10 @@ func (c *Client) CurrentUsersAlbumsOpt(opt *Options) (*SavedAlbumPage, error) {
 			spotifyURL += "?" + params
 		}
 	}
-	
+
 	var result SavedAlbumPage
 
-	err := c.Get(spotifyURL, &result)
+	err := c.get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
@@ -329,10 +329,10 @@ func (c *Client) CurrentUsersPlaylistsOpt(opt *Options) (*SimplePlaylistPage, er
 			spotifyURL += "?" + params
 		}
 	}
-	
+
 	var result SimplePlaylistPage
 
-	err := c.Get(spotifyURL, &result)
+	err := c.get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/user.go
+++ b/user.go
@@ -1,7 +1,6 @@
 package spotify
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -64,18 +63,14 @@ func GetUsersPublicProfile(userID ID) (*User, error) {
 // Spotify User.  It does not require authentication.
 func (c *Client) GetUsersPublicProfile(userID ID) (*User, error) {
 	spotifyURL := baseAddress + "users/" + string(userID)
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+
 	var user User
-	err = json.NewDecoder(resp.Body).Decode(&user)
+
+	err := c.Get(spotifyURL, &user)
 	if err != nil {
 		return nil, err
 	}
+
 	return &user, nil
 }
 
@@ -92,19 +87,13 @@ func (c *Client) GetUsersPublicProfile(userID ID) (*User, error) {
 // This email address is unverified - do not assume that Spotify has
 // checked that the email address actually belongs to the user.
 func (c *Client) CurrentUser() (*PrivateUser, error) {
-	resp, err := c.http.Get(baseAddress + "me")
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
 	var result PrivateUser
-	err = json.NewDecoder(resp.Body).Decode(&result)
+
+	err := c.Get(baseAddress + "me", &result)
 	if err != nil {
 		return nil, err
 	}
+
 	return &result, nil
 }
 
@@ -133,19 +122,14 @@ func (c *Client) CurrentUsersTracksOpt(opt *Options) (*SavedTrackPage, error) {
 			spotifyURL += "?" + params
 		}
 	}
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+	
 	var result SavedTrackPage
-	err = json.NewDecoder(resp.Body).Decode(&result)
+
+	err := c.Get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
+
 	return &result, nil
 }
 
@@ -206,19 +190,14 @@ func (c *Client) CurrentUserFollows(t string, ids ...ID) ([]bool, error) {
 	}
 	spotifyURL := fmt.Sprintf("%sme/following/contains?type=%s&ids=%s",
 		baseAddress, t, strings.Join(toStringSlice(ids), ","))
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+
 	var result []bool
-	err = json.NewDecoder(resp.Body).Decode(&result)
+
+	err := c.Get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
+
 	return result, nil
 }
 
@@ -244,7 +223,7 @@ func (c *Client) modifyFollowers(usertype string, follow bool, ids ...ID) error 
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent {
-		return decodeError(resp.Body)
+		return decodeError(c, resp)
 	}
 	return nil
 }
@@ -275,21 +254,16 @@ func (c *Client) CurrentUsersFollowedArtistsOpt(limit int, after string) (*FullA
 	if params := v.Encode(); params != "" {
 		spotifyURL += "?" + params
 	}
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+	
 	var result struct {
 		A FullArtistCursorPage `json:"artists"`
 	}
-	err = json.NewDecoder(resp.Body).Decode(&result)
+
+	err := c.Get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
+
 	return &result.A, nil
 }
 
@@ -318,19 +292,14 @@ func (c *Client) CurrentUsersAlbumsOpt(opt *Options) (*SavedAlbumPage, error) {
 			spotifyURL += "?" + params
 		}
 	}
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+	
 	var result SavedAlbumPage
-	err = json.NewDecoder(resp.Body).Decode(&result)
+
+	err := c.Get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
+
 	return &result, nil
 }
 
@@ -360,18 +329,13 @@ func (c *Client) CurrentUsersPlaylistsOpt(opt *Options) (*SimplePlaylistPage, er
 			spotifyURL += "?" + params
 		}
 	}
-	resp, err := c.http.Get(spotifyURL)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, decodeError(resp.Body)
-	}
+	
 	var result SimplePlaylistPage
-	err = json.NewDecoder(resp.Body).Decode(&result)
+
+	err := c.Get(spotifyURL, &result)
 	if err != nil {
 		return nil, err
 	}
+
 	return &result, nil
 }

--- a/user.go
+++ b/user.go
@@ -217,7 +217,7 @@ func (c *Client) modifyFollowers(usertype string, follow bool, ids ...ID) error 
 	if err != nil {
 		return err
 	}
-	err = c.execute(req)
+	err = c.executeOpt(req, http.StatusNoContent, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The Spotify API imposes rate-limits but this is obscured by the client. I added the ability to enable automatic-retries by the client (this has to be specifically enabled though). Before I did this, I had to refactor all of the requests to use common request mechanisms. These common calls:

1. Use an alternative implementation of `decodeError` that extracts the retry-interval from the headers and sets it into the `Client` struct.
2. Determine if we're to automatically retry, waits the provided amount, and then tries again.

I also added a small thing that sets our error-message to the description for the HTTP error-code if the request failed but the error-message is empty. This was really confusing when I tried to add a bunch of tracks to a playlist and it failed for no clear reason.