### PR TITLE
Changed Timestamp int to int64, could help the unmarshaling the JSON …

### DIFF
--- a/player.go
+++ b/player.go
@@ -52,7 +52,7 @@ type PlaybackContext struct {
 // CurrentlyPlaying contains the information about currently playing items
 type CurrentlyPlaying struct {
 	// Timestamp when data was fetched
-	Timestamp int `json:"timestamp"`
+	Timestamp int64 `json:"timestamp"`
 	// PlaybackContext current context
 	PlaybackContext PlaybackContext `json:"context"`
 	// Progress into the currently playing track.


### PR DESCRIPTION
…object when calling the PlayerCurrentlyPlaying(). 

For me, i had a problem with having the Timestamp as int because of the size