### PR TITLE
SimpleAlbum with SimpleArtists

### DIFF
--- a/album.go
+++ b/album.go
@@ -13,7 +13,7 @@ import (
 type SimpleAlbum struct {
 	// The name of the album.
 	Name string `json:"name"`
-	// An array of SimpleArtists
+	// A slice of SimpleArtists
 	Artists []SimpleArtist `json:"artists"`
 	// The type of the album: one of "album",
 	// "single", or "compilation".

--- a/album.go
+++ b/album.go
@@ -13,7 +13,7 @@ import (
 type SimpleAlbum struct {
 	// The name of the album.
 	Name string `json:"name"`
-	// An array of SimplifiedArtists
+	// An array of SimpleArtists
 	Artists []SimpleArtist `json:"artists"`
 	// The type of the album: one of "album",
 	// "single", or "compilation".

--- a/album.go
+++ b/album.go
@@ -13,6 +13,8 @@ import (
 type SimpleAlbum struct {
 	// The name of the album.
 	Name string `json:"name"`
+	// An array of SimplifiedArtists
+	Artists []SimpleArtist `json:"artists"`
 	// The type of the album: one of "album",
 	// "single", or "compilation".
 	AlbumType string `json:"album_type"`


### PR DESCRIPTION
# Added a slice of SimpleArtists to the SimpleAlbum struct

Hey, I've recently used this package for a project, and found that I needed the array of artists which the Spotify API returns when searching for albums. Therefore I decided to also create a pull request in case you're interested in implementing this change.

