### PR TITLE
Support for "client credentials" flow.

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -182,7 +182,7 @@ func (c *Client) Token() (*oauth2.Token, error) {
 
 // Creates a new client that uses the "client credentials" flow, described here:
 // https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow
-func NewClientWithClientCreds(ctx context.Context, clientID, secretKey string) Client {
+func NewClientWithCredentials(ctx context.Context, clientID, secretKey string) Client {
 	config := &clientcredentials.Config{
 		ClientID:     clientID,
 		ClientSecret: secretKey,

--- a/auth.go
+++ b/auth.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
 )
 
 const (
@@ -177,4 +178,19 @@ func (c *Client) Token() (*oauth2.Token, error) {
 	}
 
 	return t, nil
+}
+
+// Creates a new client that uses the "client credentials" flow, described here:
+// https://developer.spotify.com/documentation/general/guides/authorization-guide/#client-credentials-flow
+func NewClientWithClientCreds(ctx context.Context, clientID, secretKey string) Client {
+	config := &clientcredentials.Config{
+		ClientID:     clientID,
+		ClientSecret: secretKey,
+		TokenURL:     TokenURL,
+	}
+
+	return Client{
+		http:    config.Client(ctx),
+		baseURL: baseAddress,
+	}
 }


### PR DESCRIPTION
Originally reported in: https://github.com/zmb3/spotify/issues/37. The workaround posted there does not allow the token to be automatically refreshed -`oauth2.clientcredentials.Config.Client()` must be used to create the Client.

Open to a better name for this method :)