### PR TITLE
Client.get: on 204, return early

### DIFF
--- a/spotify.go
+++ b/spotify.go
@@ -214,6 +214,9 @@ func (c *Client) get(url string, result interface{}) error {
 			time.Sleep(retryDuration(resp))
 			continue
 		}
+		if resp.StatusCode == http.StatusNoContent {
+			return nil
+		}
 		if resp.StatusCode != http.StatusOK {
 			return c.decodeError(resp)
 		}


### PR DESCRIPTION
I had only previously checked the issues and not the pull requests, but this is actually a duplicate of https://github.com/zmb3/spotify/pull/81. I do think it would make sense to do this check in Client.get as well as (or instead of) Client.execute, though.