### PR TITLE
Add AuthURLWithDialog to force app authentication with Spotify

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -131,6 +131,11 @@ func (a Authenticator) AuthURL(state string) string {
 	return a.config.AuthCodeURL(state)
 }
 
+// AuthURLWithDialog returns the same URL as AuthURL, but sets show_dialog to true
+func (a Authenticator) AuthURLWithDialog(state string) string {
+	return a.config.AuthCodeURL(state, oauth2.SetAuthURLParam("show_dialog", "true"))
+}
+
 // Token pulls an authorization code from an HTTP request and attempts to exchange
 // it for an access token.  The standard use case is to call Token from the handler
 // that handles requests to your application's redirect URL.


### PR DESCRIPTION
#94 Added a new showDialog boolean to the `Authenticator` struct and a setter method for it. For now, it is initialized to false by default. I didn't want to break the existing API/flow, so I didn't add it to the constructor or existing configuration methods. I would love any feedback/suggestions/changes as I am not super familiar with Go code bases :)