### PR TITLE
[Minor] Correct Misspellings

### DIFF
--- a/category.go
+++ b/category.go
@@ -28,7 +28,7 @@ type Category struct {
 // category strings in a particular language (for example: "es_MX" means
 // get categories in Mexico, returned in Spanish).
 //
-// This call requries authorization.
+// This call requires authorization.
 func (c *Client) GetCategoryOpt(id, country, locale string) (Category, error) {
 	cat := Category{}
 	spotifyURL := fmt.Sprintf("%sbrowse/categories/%s", c.baseURL, id)
@@ -57,7 +57,7 @@ func (c *Client) GetCategory(id string) (Category, error) {
 	return c.GetCategoryOpt(id, "", "")
 }
 
-// GetCategoryPlaylists gets a list of Spotify playlists tagged with a paricular category.
+// GetCategoryPlaylists gets a list of Spotify playlists tagged with a particular category.
 func (c *Client) GetCategoryPlaylists(catID string) (*SimplePlaylistPage, error) {
 	return c.GetCategoryPlaylistsOpt(catID, nil)
 }

--- a/playlist.go
+++ b/playlist.go
@@ -68,7 +68,7 @@ type PlaylistOptions struct {
 	// in the Spotify default language (American English).
 	Locale *string
 	// A timestamp in ISO 8601 format (yyyy-MM-ddTHH:mm:ss).
-	// use this paramter to specify the user's local time to
+	// use this parameter to specify the user's local time to
 	// get results tailored for that specific date and time
 	// in the day.  If not provided, the response defaults to
 	// the current UTC time.
@@ -177,7 +177,7 @@ func (c *Client) GetPlaylistsForUser(userID string) (*SimplePlaylistPage, error)
 	return c.GetPlaylistsForUserOpt(userID, nil)
 }
 
-// GetPlaylistsForUserOpt is like PlaylistsForUser, but it accepts optional paramters
+// GetPlaylistsForUserOpt is like PlaylistsForUser, but it accepts optional parameters
 // for filtering the results.
 func (c *Client) GetPlaylistsForUserOpt(userID string, opt *Options) (*SimplePlaylistPage, error) {
 	spotifyURL := c.baseURL + "users/" + userID + "/playlists"
@@ -529,7 +529,7 @@ func (c *Client) removeTracksFromPlaylist(playlistID ID,
 }
 
 // ReplacePlaylistTracks replaces all of the tracks in a playlist, overwriting its
-// exising tracks  This can be useful for replacing or reordering tracks, or for
+// existing tracks  This can be useful for replacing or reordering tracks, or for
 // clearing a playlist.
 //
 // Modifying a public playlist requires that the user has authorized the

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -305,7 +305,7 @@ func TestRemoveTracksFromPlaylist(t *testing.T) {
 			t.Error("Track object doesn't contain 'uri' field")
 		}
 		if trackURI != "spotify:track:track1" {
-			t.Errorf("Expeced URI: 'spotify:track:track1', got '%s'\n", trackURI)
+			t.Errorf("Expected URI: 'spotify:track:track1', got '%s'\n", trackURI)
 		}
 	})
 	defer server.Close()

--- a/search.go
+++ b/search.go
@@ -69,7 +69,7 @@ type SearchResult struct {
 // Operators
 //
 // The operator NOT can be used to exclude results.  For example,
-// query = "roadhouse NOT blues" returns items that match "roadhouse" but exludes
+// query = "roadhouse NOT blues" returns items that match "roadhouse" but excludes
 // those that also contain the keyword "blues".  Similarly, the OR operator can
 // be used to broaden the search.  query = "roadhouse OR blues" returns all results
 // that include either of the terms.  Only one OR operator can be used in a query.


### PR DESCRIPTION
Misspelled words were caught by the Misspell package of the Go Report Card tool.
Before: https://goreportcard.com/report/github.com/zmb3/spotify#misspell
After: https://goreportcard.com/report/github.com/fgoyer/spotify#misspell