### PR TITLE
Remove deprecated UserReadBirthdate

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -52,8 +52,6 @@ const (
 	ScopeUserReadPrivate = "user-read-private"
 	// ScopeUserReadEmail seeks read access to a user's email address.
 	ScopeUserReadEmail = "user-read-email"
-	// ScopeUserReadBirthdate seeks read access to a user's birthdate.
-	ScopeUserReadBirthdate = "user-read-birthdate"
 	// ScopeUserReadCurrentlyPlaying seeks read access to a user's currently playing track
 	ScopeUserReadCurrentlyPlaying = "user-read-currently-playing"
 	// ScopeUserReadPlaybackState seeks read access to the user's current playback state


### PR DESCRIPTION
Hi there, I was trying to use the library with another project and I've found a weird behavior when trying to authenticate against the API using the `UserReadBirthdate` scope. I've spent some time doing a research about the scope, and it is not available anymore in [Spotify's API docs](https://developer.spotify.com/documentation/general/guides/scopes/).

I've also found some issues at oficial Spotify's GitHub repositories and seems that this scope was deprecated.

Also, I didn't changed any test because there are no tests for this file in the library. 

https://github.com/spotify/web-playback-sdk/issues/11#issuecomment-538620631
https://github.com/spotify/web-api/issues/1262#issuecomment-524833983