### PR TITLE
Add New(...) constructor for client

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -162,10 +162,7 @@ func (a Authenticator) Exchange(code string) (*oauth2.Token, error) {
 // NewClient creates a Client that will use the specified access token for its API requests.
 func (a Authenticator) NewClient(token *oauth2.Token) Client {
 	client := a.config.Client(a.context, token)
-	return Client{
-		http:    client,
-		baseURL: baseAddress,
-	}
+	return New(WithHTTPClient(client))
 }
 
 // Token gets the client's current token.

--- a/spotify.go
+++ b/spotify.go
@@ -40,6 +40,18 @@ const (
 
 const baseAddress = "https://api.spotify.com/v1/"
 
+type ClientOptions struct {
+	HTTPClient *http.Client
+}
+
+type ClientOption func(*ClientOptions)
+
+func WithHTTPClient(client *http.Client) ClientOption {
+	return func(args *ClientOptions) {
+		args.HTTPClient = client
+	}
+}
+
 // Client is a client for working with the Spotify Web API.
 // To create an authenticated client, use the `Authenticator.NewClient` method.
 type Client struct {
@@ -47,6 +59,21 @@ type Client struct {
 	baseURL string
 
 	AutoRetry bool
+}
+
+// New returns a new Spotify client. It is recommended that you use
+// spotify.NewAuthenticator to create a client.
+func New(setters ...ClientOption) Client {
+	args := &ClientOptions{}
+
+	for _, setter := range setters {
+		setter(args)
+	}
+
+	return Client{
+		http:    args.HTTPClient,
+		baseURL: baseAddress,
+	}
 }
 
 // URI identifies an artist, album, track, or category.  For example,

--- a/spotify_test.go
+++ b/spotify_test.go
@@ -21,11 +21,8 @@ func testClient(code int, body io.Reader, validators ...func(*http.Request)) (*C
 			closer.Close()
 		}
 	}))
-	client := &Client{
-		http:    http.DefaultClient,
-		baseURL: server.URL + "/",
-	}
-	return client, server
+	client := New(WithHTTPClient(http.DefaultClient), withBaseURL(server.URL+"/"))
+	return &client, server
 }
 
 // Returns a client whose requests will always return
@@ -91,7 +88,7 @@ func TestNewReleasesRateLimitExceeded(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := &Client{http: http.DefaultClient, baseURL: server.URL + "/", AutoRetry: true}
+	client := New(WithHTTPClient(http.DefaultClient), WithAutoRetry(true), withBaseURL(server.URL+"/"))
 	releases, err := client.NewReleases()
 	if err != nil {
 		t.Fatal(err)

--- a/user_test.go
+++ b/user_test.go
@@ -144,7 +144,7 @@ func TestFollowArtistAutoRetry(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := &Client{http: http.DefaultClient, baseURL: server.URL + "/", AutoRetry: true}
+	client := New(WithHTTPClient(http.DefaultClient), withBaseURL(server.URL+"/"), WithAutoRetry(true))
 	if err := client.FollowArtist("3ge4xOaKvWfhRwgx0Rldov"); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Hi!

I'd like to instantiate my own Spotify client. Following [this](https://developers.google.com/calendar/quickstart/go) Google Oauth example, I want to do something like
```golang
	httpClient, err := util.GetOauthClient(context.TODO(), cfg, "spotifycreds.json")
	if err != nil {
		return spotify.Client{}, fmt.Errorf("GetOauthClient(): %w", err)
	}

	return spotify.New(spotify.WithHTTPClient(httpClient)), nil
```

I've written generic boilerplate for generating an oauth client that I can use for multiple libs, like google's calendar lib ([here](https://gist.github.com/jchorl/f5933485593e6cd1ab1450a0e607482f))

I opted to follow the functional options pattern described [here](https://github.com/tmrts/go-patterns/blob/f978e420361704bd7531e2b57905a308a3a012c8/idiom/functional-options.md) and also modified the tests to test out the new constructor.

The docs are updated to still recommend the standard auth flow.

Let me know what you think!