### PR TITLE
Client.execute: Don't return EOF for response status 204

### DIFF
--- a/spotify.go
+++ b/spotify.go
@@ -174,6 +174,9 @@ func (c *Client) execute(req *http.Request, result interface{}, needsStatus ...i
 			time.Sleep(retryDuration(resp))
 			continue
 		}
+		if resp.StatusCode == http.StatusNoContent {
+			return nil
+		}
 		if (resp.StatusCode >= 300 ||
 			resp.StatusCode < 200) &&
 			isFailure(resp.StatusCode, needsStatus) {


### PR DESCRIPTION
Implements the behaviour from #88 for `client.execute()` as well.

This prevents an EOF error when client.execute() receives status 204 (No Content), e.g. when `client.PlayerCurrentlyPlaying()` is called while nothing is playing.

Resolves #109.