### PR TITLE
add support for a user's saved songs

### DIFF
--- a/examples/library/savedtracks.go
+++ b/examples/library/savedtracks.go
@@ -1,0 +1,82 @@
+// This example demonstrates how to retrieve songs in a users library. It uses
+// authentication and paging, in particular see `examples/authenticate/authcode`
+// and `examples/paging`. In order to run this example yourself, you'll need to:
+//
+//  1. Register an application at: https://developer.spotify.com/my-applications/
+//       - Use "http://localhost:8080/callback" as the redirect URI
+//  2. Set the SPOTIFY_ID environment variable to the client ID you got in step 1.
+//  3. Set the SPOTIFY_SECRET environment variable to the client secret from step 1.
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/zmb3/spotify"
+)
+
+// redirectURI is the OAuth redirect URI for the application.
+// You must register an application at Spotify's developer portal
+// and enter this value.
+const redirectURI = "http://localhost:8080/callback"
+
+var (
+	auth  = spotify.NewAuthenticator(redirectURI, spotify.ScopeUserLibraryRead)
+	ch    = make(chan *spotify.Client)
+	state = "abc123"
+)
+
+func main() {
+	// first start an HTTP server
+	http.HandleFunc("/callback", completeAuth)
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Got request for:", r.URL.String())
+	})
+	go http.ListenAndServe(":8080", nil)
+
+	url := auth.AuthURL(state)
+	fmt.Println("Please log in to Spotify by visiting the following page in your browser:", url)
+
+	// wait for auth to complete
+	client := <-ch
+
+	// use the client to make calls that require authorization
+	user, err := client.CurrentUser()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("You are logged in as:", user.ID)
+  result, err := client.UserSavedTracks(10)
+  if err != nil {
+    log.Fatal(err)
+  }
+
+  fmt.Printf("You have %d songs in your library, here is some of them:\n", result.Total)
+
+  for i:=0; i < 3; i++ {
+    for j:=0; j < len(result.Tracks); j++ {
+      fmt.Println(result.Tracks[j].Name)
+    }
+    err = client.NextPage(&result)
+    if err != nil {
+      break
+    }
+  }
+}
+
+func completeAuth(w http.ResponseWriter, r *http.Request) {
+	tok, err := auth.Token(state, r)
+	if err != nil {
+		http.Error(w, "Couldn't get token", http.StatusForbidden)
+		log.Fatal(err)
+	}
+	if st := r.FormValue("state"); st != state {
+		http.NotFound(w, r)
+		log.Fatalf("State mismatch: %s != %s\n", st, state)
+	}
+	// use the token to get an authenticated client
+	client := auth.NewClient(tok)
+	fmt.Fprintf(w, "Login Completed!")
+	ch <- &client
+}

--- a/library.go
+++ b/library.go
@@ -59,3 +59,32 @@ func (c *Client) modifyLibraryTracks(add bool, ids ...ID) error {
 	}
 	return nil
 }
+
+// UserSavedTracks returns the tracks which the current user has saved. This 
+// call requires the ScopeUserLibraryRead scope. Limit specifies the max items
+// per page.
+func (c *Client) UserSavedTracks(limit int) (SavedTrackPage, error) {
+  return c.UserSavedTracksOpt(limit, 0, "")
+}
+
+// UserSavedTracksOpt returns tracks which the current user has saved. This
+// call requires the ScopeUserLibraryRead scope. Limit and offset are used for
+// manual paging. Limit is the max number of objects to return in the page,
+// offset is the index of the first object in the page. Market is an ISO 3166-1
+// alpha-2 country code, or the string "from_token". This is used for track
+// relinking, use the empty string to leave this unspecified.
+func (c *Client) UserSavedTracksOpt(limit int, offset uint, market string)(SavedTrackPage, error) {
+  var result SavedTrackPage
+  if limit > 50 || limit < 1 {
+    return result, errors.New("spotify: SavedTracks supports a limit of 1 to 50")
+  }
+  spotifyURL := fmt.Sprintf("%sme/tracks?limit=%d", c.baseURL, limit)
+  if offset != 0 {
+    spotifyURL = fmt.Sprintf("%s&offset=%d", spotifyURL, offset)
+  }
+  if market != "" {
+    spotifyURL = fmt.Sprintf("%s&market=%s", spotifyURL, market)
+  }
+  err := c.get(spotifyURL, &result)
+  return result, err
+}


### PR DESCRIPTION
Added the functions `UserSavedTracks` and `UserSavedTracksOpt` which implement the api endpoint documented [here](https://developer.spotify.com/documentation/web-api/reference/library/get-users-saved-tracks/). Also threw in an example of it being used.
