### PR TITLE
Add optional URL params to URL and Token functions 

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -136,7 +136,7 @@ func (a Authenticator) AuthURLWithDialog(state string) string {
 	return a.config.AuthCodeURL(state, oauth2.SetAuthURLParam("show_dialog", "true"))
 }
 
-// AuthURLWithOpts returns the bause AuthURL along with any extra URL params
+// AuthURLWithOpts returns the bause AuthURL along with any extra URL Auth params
 func (a Authenticator) AuthURLWithOpts(state string, opts ...oauth2.AuthCodeOption) string {
 	return a.config.AuthCodeURL(state, opts...)
 }
@@ -160,6 +160,8 @@ func (a Authenticator) Token(state string, r *http.Request) (*oauth2.Token, erro
 	return a.config.Exchange(a.context, code)
 }
 
+// TokenWithOpts performs the same function as the Authenticator Token function
+// but takes in optional URL Auth params
 func (a Authenticator) TokenWithOpts(state string, r *http.Request, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
 	values := r.URL.Query()
 	if e := values.Get("error"); e != "" {

--- a/examples/authenticate/pkce/pkce.go
+++ b/examples/authenticate/pkce/pkce.go
@@ -1,0 +1,73 @@
+// This example demonstrates how to authenticate with Spotify using the authorization code flow.
+// In order to run this example yourself, you'll need to:
+//
+//  1. Register an application at: https://developer.spotify.com/my-applications/
+//       - Use "http://localhost:8080/callback" as the redirect URI
+//  2. Set the SPOTIFY_ID environment variable to the client ID you got in step 1.
+//  3. Set the SPOTIFY_SECRET environment variable to the client secret from step 1.
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"golang.org/x/oauth2"
+
+	pkce "github.com/frankmoreno/oauth2-pkce"
+	"github.com/zmb3/spotify"
+)
+
+// redirectURI is the OAuth redirect URI for the application.
+// You must register an application at Spotify's developer portal
+// and enter this value.
+const redirectURI = "http://localhost:8080/callback"
+
+var (
+	auth            = spotify.NewAuthenticator(redirectURI, spotify.ScopeUserReadPrivate)
+	ch              = make(chan *spotify.Client)
+	state           = "abc123"
+	codeVerifier, _ = pkce.GenerateCodeVerifier(64, true)
+)
+
+func main() {
+	// first start an HTTP server
+	http.HandleFunc("/callback", completeAuth)
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Println("Got request for:", r.URL.String())
+	})
+	go http.ListenAndServe(":8080", nil)
+
+	challenge := pkce.GenerateCodeChallenge(codeVerifier, true)
+	url := auth.AuthURLWithOpts(state,
+		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
+		oauth2.SetAuthURLParam("code_challenge", challenge),
+	)
+	fmt.Println("Please log in to Spotify by visiting the following page in your browser:", url)
+
+	// wait for auth to complete
+	client := <-ch
+
+	// use the client to make calls that require authorization
+	user, err := client.CurrentUser()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("You are logged in as:", user.ID)
+}
+
+func completeAuth(w http.ResponseWriter, r *http.Request) {
+	tok, err := auth.TokenWithOpts(state, r, oauth2.SetAuthURLParam("code_verifier", codeVerifier))
+	if err != nil {
+		http.Error(w, "Couldn't get token", http.StatusForbidden)
+		log.Fatal(err)
+	}
+	if st := r.FormValue("state"); st != state {
+		http.NotFound(w, r)
+		log.Fatalf("State mismatch: %s != %s\n", st, state)
+	}
+	// use the token to get an authenticated client
+	client := auth.NewClient(tok)
+	fmt.Fprintf(w, "Login Completed!")
+	ch <- &client
+}

--- a/examples/authenticate/pkce/pkce.go
+++ b/examples/authenticate/pkce/pkce.go
@@ -58,7 +58,8 @@ func main() {
 }
 
 func completeAuth(w http.ResponseWriter, r *http.Request) {
-	tok, err := auth.TokenWithOpts(state, r, oauth2.SetAuthURLParam("code_verifier", codeVerifier))
+	tok, err := auth.TokenWithOpts(state, r,
+		oauth2.SetAuthURLParam("code_verifier", codeVerifier))
 	if err != nil {
 		http.Error(w, "Couldn't get token", http.StatusForbidden)
 		log.Fatal(err)

--- a/examples/authenticate/pkce/pkce.go
+++ b/examples/authenticate/pkce/pkce.go
@@ -1,10 +1,9 @@
-// This example demonstrates how to authenticate with Spotify using the authorization code flow.
+// This example demonstrates how to authenticate with Spotify using the authorization code flow with PKCE.
 // In order to run this example yourself, you'll need to:
 //
 //  1. Register an application at: https://developer.spotify.com/my-applications/
 //       - Use "http://localhost:8080/callback" as the redirect URI
 //  2. Set the SPOTIFY_ID environment variable to the client ID you got in step 1.
-//  3. Set the SPOTIFY_SECRET environment variable to the client secret from step 1.
 package main
 
 import (
@@ -14,7 +13,6 @@ import (
 
 	"golang.org/x/oauth2"
 
-	pkce "github.com/frankmoreno/oauth2-pkce"
 	"github.com/zmb3/spotify"
 )
 
@@ -24,10 +22,14 @@ import (
 const redirectURI = "http://localhost:8080/callback"
 
 var (
-	auth            = spotify.NewAuthenticator(redirectURI, spotify.ScopeUserReadPrivate)
-	ch              = make(chan *spotify.Client)
-	state           = "abc123"
-	codeVerifier, _ = pkce.GenerateCodeVerifier(64, true)
+	auth  = spotify.NewAuthenticator(redirectURI, spotify.ScopeUserReadPrivate)
+	ch    = make(chan *spotify.Client)
+	state = "abc123"
+	// These should be randomly generated for each request
+	//  More information on generating these can be found here,
+	// https://www.oauth.com/playground/authorization-code-with-pkce.html
+	codeVerifier  = "w0HfYrKnG8AihqYHA9_XUPTIcqEXQvCQfOF2IitRgmlF43YWJ8dy2b49ZUwVUOR.YnvzVoTBL57BwIhM4ouSa~tdf0eE_OmiMC_ESCcVOe7maSLIk9IOdBhRstAxjCl7"
+	codeChallenge = "ZhZJzPQXYBMjH8FlGAdYK5AndohLzFfZT-8J7biT7ig"
 )
 
 func main() {
@@ -38,10 +40,9 @@ func main() {
 	})
 	go http.ListenAndServe(":8080", nil)
 
-	challenge := pkce.GenerateCodeChallenge(codeVerifier, true)
 	url := auth.AuthURLWithOpts(state,
 		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
-		oauth2.SetAuthURLParam("code_challenge", challenge),
+		oauth2.SetAuthURLParam("code_challenge", codeChallenge),
 	)
 	fmt.Println("Please log in to Spotify by visiting the following page in your browser:", url)
 


### PR DESCRIPTION
This allows for support of the PKCE authentication flow along with any other flows that might require extra URL params on the token or auth URL.