### PR TITLE
Fixing CurrentUsersTracksOpt market query parameter + proper handling of results

### DIFF
--- a/album_test.go
+++ b/album_test.go
@@ -89,7 +89,8 @@ func TestFindAlbumTracks(t *testing.T) {
 	client, server := testClientFile(http.StatusOK, "test_data/find_album_tracks.txt")
 	defer server.Close()
 
-	res, err := client.GetAlbumTracksOpt(ID("0sNOF9WDwhWunNAHPD3Baj"), 1, 0)
+	limit := 1
+	res, err := client.GetAlbumTracksOpt(ID("0sNOF9WDwhWunNAHPD3Baj"), &Options{Limit: &limit})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/track.go
+++ b/track.go
@@ -39,6 +39,25 @@ func (st SimpleTrack) String() string {
 	return fmt.Sprintf("TRACK<[%s] [%s]>", st.ID, st.Name)
 }
 
+// LinkedFromInfo
+// See: https://developer.spotify.com/documentation/general/guides/track-relinking-guide/
+type LinkedFromInfo struct {
+	// ExternalURLs are the known external APIs for this track or album
+	ExternalURLs map[string]string `json:"external_urls"`
+
+	// Href is a link to the Web API endpoint providing full details
+	Href string `json:"href"`
+
+	// ID of the linked track
+	ID ID `json:"id"`
+
+	// Type of the link: album of the track
+	Type string `json:"type"`
+
+	// URI is the Spotify URI of the track/album
+	URI string `json:"uri"`
+}
+
 // FullTrack provides extra track data in addition to what is provided by SimpleTrack.
 type FullTrack struct {
 	SimpleTrack
@@ -51,10 +70,14 @@ type FullTrack struct {
 	// both total plays and most recent plays.
 	Popularity int `json:"popularity"`
 
-	// IsPlayable defines if the track is playable. It's reported when the "market" parameter is passed to the track
+	// IsPlayable defines if the track is playable. It's reported when the "market" parameter is passed to the tracks
 	// listing API.
 	// See: https://developer.spotify.com/documentation/general/guides/track-relinking-guide/
 	IsPlayable *bool `json:"is_playable"`
+
+	// LinkedFrom points to the linked track. It's reported when the "market" parameter is passed to the tracks listing
+	// API.
+	LinkedFrom *LinkedFromInfo `json:"linked_from"`
 }
 
 // PlaylistTrack contains info about a track in a playlist.

--- a/track.go
+++ b/track.go
@@ -50,6 +50,11 @@ type FullTrack struct {
 	// with 100 being the most popular.  The popularity is calculated from
 	// both total plays and most recent plays.
 	Popularity int `json:"popularity"`
+
+	// IsPlayable defines if the track is playable. It's reported when the "market" parameter is passed to the track
+	// listing API.
+	// See: https://developer.spotify.com/documentation/general/guides/track-relinking-guide/
+	IsPlayable *bool `json:"is_playable"`
 }
 
 // PlaylistTrack contains info about a track in a playlist.

--- a/user.go
+++ b/user.go
@@ -100,11 +100,13 @@ func (c *Client) CurrentUsersShows() (*SavedShowPage, error) {
 
 // CurrentUsersShowsOpt is like CurrentUsersShows, but it accepts additional
 // options for sorting and filtering the results.
+// API Doc: https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-saved-shows
 func (c *Client) CurrentUsersShowsOpt(opt *Options) (*SavedShowPage, error) {
 	spotifyURL := c.baseURL + "me/shows"
 	if opt != nil {
 		v := url.Values{}
 		if opt.Country != nil {
+			// Note: This parameter doesn't actually exist
 			v.Set("country", *opt.Country)
 		}
 		if opt.Limit != nil {
@@ -136,12 +138,13 @@ func (c *Client) CurrentUsersTracks() (*SavedTrackPage, error) {
 
 // CurrentUsersTracksOpt is like CurrentUsersTracks, but it accepts additional
 // options for sorting and filtering the results.
+// API Doc: https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-saved-tracks
 func (c *Client) CurrentUsersTracksOpt(opt *Options) (*SavedTrackPage, error) {
 	spotifyURL := c.baseURL + "me/tracks"
 	if opt != nil {
 		v := url.Values{}
 		if opt.Country != nil {
-			v.Set("country", *opt.Country)
+			v.Set("market", *opt.Country)
 		}
 		if opt.Limit != nil {
 			v.Set("limit", strconv.Itoa(*opt.Limit))

--- a/user.go
+++ b/user.go
@@ -105,10 +105,6 @@ func (c *Client) CurrentUsersShowsOpt(opt *Options) (*SavedShowPage, error) {
 	spotifyURL := c.baseURL + "me/shows"
 	if opt != nil {
 		v := url.Values{}
-		if opt.Country != nil {
-			// Note: This parameter doesn't actually exist
-			v.Set("country", *opt.Country)
-		}
 		if opt.Limit != nil {
 			v.Set("limit", strconv.Itoa(*opt.Limit))
 		}
@@ -137,7 +133,7 @@ func (c *Client) CurrentUsersTracks() (*SavedTrackPage, error) {
 }
 
 // CurrentUsersTracksOpt is like CurrentUsersTracks, but it accepts additional
-// options for sorting and filtering the results.
+// options for track relinking, sorting and filtering the results.
 // API Doc: https://developer.spotify.com/documentation/web-api/reference-beta/#endpoint-get-users-saved-tracks
 func (c *Client) CurrentUsersTracksOpt(opt *Options) (*SavedTrackPage, error) {
 	spotifyURL := c.baseURL + "me/tracks"


### PR DESCRIPTION
Thank you for this great lib. 

- The `me/tracks` API uses the `market` query parameter instead of `country`.
- When the `market` query parameter is passed, an `is_playable` and `linked_from` key is returned.

Updating all the API to support track relinking:
- [x] Get a Track
- [x] Get Several Tracks
- [x] Get an Album
- [x] Get Several Albums
- [x] Get an Album’s Tracks
- [x] Get a Playlist’s Tracks
- [x] Get a User’s Saved Tracks
