### PR TITLE
Fix spelling of a JSON key

### DIFF
--- a/player.go
+++ b/player.go
@@ -60,7 +60,7 @@ type CurrentlyPlaying struct {
 	// Playing If something is currently playing.
 	Playing bool `json:"is_playing"`
 	// The currently playing track. Can be null.
-	Item *FullTrack `json:"Item"`
+	Item *FullTrack `json:"item"`
 }
 
 type RecentlyPlayedItem struct {


### PR DESCRIPTION
The JSON key for the item object in the CurrentlyPlaying struct is now in lowercase. See [https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-the-users-currently-playing-track](https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-the-users-currently-playing-track)