### PR TITLE
Accept collaborative parameter for CreatePlaylistForUser

### DIFF
--- a/playlist.go
+++ b/playlist.go
@@ -308,8 +308,6 @@ func (c *Client) GetPlaylistTracksOpt(playlistID ID,
 // Creating a public playlist for a user requires ScopePlaylistModifyPublic;
 // creating a private playlist requires ScopePlaylistModifyPrivate.
 //
-// Collaborative playlists must be private.
-//
 // On success, the newly created playlist is returned.
 // TODO Accept a collaborative parameter and delete
 // CreateCollaborativePlaylistForUser.

--- a/playlist.go
+++ b/playlist.go
@@ -308,17 +308,21 @@ func (c *Client) GetPlaylistTracksOpt(playlistID ID,
 // Creating a public playlist for a user requires ScopePlaylistModifyPublic;
 // creating a private playlist requires ScopePlaylistModifyPrivate.
 //
+// Collaborative playlists must be private.
+//
 // On success, the newly created playlist is returned.
-func (c *Client) CreatePlaylistForUser(userID, playlistName, description string, public bool) (*FullPlaylist, error) {
+func (c *Client) CreatePlaylistForUser(userID, playlistName, description string, public, collaborative bool) (*FullPlaylist, error) {
 	spotifyURL := fmt.Sprintf("%susers/%s/playlists", c.baseURL, userID)
 	body := struct {
-		Name        string `json:"name"`
-		Public      bool   `json:"public"`
-		Description string `json:"description"`
+		Name          string `json:"name"`
+		Public        bool   `json:"public"`
+		Description   string `json:"description"`
+		Collaborative bool   `json:"collaborative"`
 	}{
 		playlistName,
 		public,
 		description,
+		collaborative,
 	}
 	bodyJSON, err := json.Marshal(body)
 	if err != nil {

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -154,9 +154,10 @@ func TestUserFollowsPlaylist(t *testing.T) {
 	}
 }
 
+// NOTE collaborative is a fmt boolean.
 var newPlaylist = `
 {
-"collaborative": %v,
+"collaborative": %t,
 "description": "Test Description",
 "external_urls": {
 	"spotify": "http://open.spotify.com/user/thelinmichael/playlist/7d2D2S200NyUE5KYs80PwO"
@@ -197,7 +198,7 @@ func TestCreatePlaylist(t *testing.T) {
 	client, server := testClientString(http.StatusCreated, fmt.Sprintf(newPlaylist, false))
 	defer server.Close()
 
-	p, err := client.CreatePlaylistForUser("thelinmichael", "A New Playlist", "Test Description", false, false)
+	p, err := client.CreatePlaylistForUser("thelinmichael", "A New Playlist", "Test Description", false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -218,27 +219,11 @@ func TestCreatePlaylist(t *testing.T) {
 	}
 }
 
-func TestCreatePublicCollaborativePlaylist(t *testing.T) {
-	client, server := testClientString(http.StatusBadRequest, `{
-			"error": {
-				"status": 400,
-				"message": "Collaborative playlists can only be private."
-			}
-		}`,
-	)
-	defer server.Close()
-
-	_, err := client.CreatePlaylistForUser("thelinmichael", "A New Playlist", "Test Description", true, true)
-	if err == nil {
-		t.Error("Expected error creating public, collaborative playlist")
-	}
-}
-
-func TestCreatePrivateCollaborativePlaylist(t *testing.T) {
+func TestCreateCollaborativePlaylist(t *testing.T) {
 	client, server := testClientString(http.StatusCreated, fmt.Sprintf(newPlaylist, true))
 	defer server.Close()
 
-	p, err := client.CreatePlaylistForUser("thelinmichael", "A New Playlist", "Test Description", false, true)
+	p, err := client.CreateCollaborativePlaylistForUser("thelinmichael", "A New Playlist", "Test Description")
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
The collaborative parameter is optional in the Spotify Web API, and was
not supported in this library. I add the parameter to directly to the
CreatePlaylistForUser function, though a case could be made for writing
a separate function in order to avoid breaking existing calls.

Note that I do not check for the relationship between public and
collaborative in the body of the function, instead I let the Web API
return an error.

I added two tests for the private/public-collaborative permutations in
order to demonstrate the intended usage of the fields.