### PR TITLE
PlaybackOffset Position field is updated from int to *int

### DIFF
--- a/player.go
+++ b/player.go
@@ -84,7 +84,7 @@ type RecentlyPlayedResult struct {
 // the request may be accepted but with an unpredictable resulting action on playback.
 type PlaybackOffset struct {
 	// Position is zero based and can’t be negative.
-	Position int `json:"position"`
+	Position *int `json:"position,omitempty"`
 	// URI is a string representing the uri of the item to start at.
 	URI URI `json:"uri,omitempty"`
 }


### PR DESCRIPTION
Hi, after the fix mentioned here: https://github.com/zmb3/spotify/issues/161 playing with the PlaybackOffset URI parameter seems to be broken. 

Although Position parameter is not set, since it has a default value 0 and there is no omitempty, it's always sent to spotify api. So that changing it to some nullable type and adding omitempty again seems to fix the issue here. 

