### PR TITLE
Remove 202 from shouldRetry

### DIFF
--- a/spotify.go
+++ b/spotify.go
@@ -187,7 +187,7 @@ func (c *Client) decodeError(resp *http.Response) error {
 // shouldRetry determines whether the status code indicates that the
 // previous operation should be retried at a later time
 func shouldRetry(status int) bool {
-	return status == http.StatusAccepted || status == http.StatusTooManyRequests
+	return status == http.StatusTooManyRequests
 }
 
 // isFailure determines whether the code indicates failure


### PR DESCRIPTION
Fixes #182

**NOTE: I don't know if `http.StatusAccepted` is used by other endpoints in cases where the response needs to be retried.**