### PR TITLE
Add ReplacePlaylistItems

### DIFF
--- a/playlist.go
+++ b/playlist.go
@@ -570,7 +570,7 @@ func (c *Client) ReplacePlaylistItems(ctx context.Context, playlistID ID, items 
 		SnapshotID string `json:"snapshot_id"`
 	}{}
 
-	err = c.execute(req, result, http.StatusCreated)
+	err = c.execute(req, &result, http.StatusCreated)
 	if err != nil {
 		return "", err
 	}

--- a/playlist.go
+++ b/playlist.go
@@ -540,6 +540,44 @@ func (c *Client) ReplacePlaylistTracks(ctx context.Context, playlistID ID, track
 	return nil
 }
 
+// ReplacePlaylistItems replaces all the items in a playlist, overwriting its
+// existing tracks  This can be useful for replacing or reordering tracks, or for
+// clearing a playlist.
+//
+// Modifying a public playlist requires that the user has authorized the
+// ScopePlaylistModifyPublic scope.  Modifying a private playlist requires the
+// ScopePlaylistModifyPrivate scope.
+//
+// A maximum of 100 tracks is permited in this call.  Additional tracks must be
+// added via AddTracksToPlaylist.
+func (c *Client) ReplacePlaylistItems(ctx context.Context, playlistID ID, items ...URI) (string, error) {
+	m := make(map[string]interface{})
+	m["uris"] = items
+
+	body, err := json.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+
+	spotifyURL := fmt.Sprintf("%splaylists/%s/tracks", c.baseURL, playlistID)
+	req, err := http.NewRequestWithContext(ctx, "PUT", spotifyURL, bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	result := struct {
+		SnapshotID string `json:"snapshot_id"`
+	}{}
+
+	err = c.execute(req, result, http.StatusCreated)
+	if err != nil {
+		return "", err
+	}
+
+	return result.SnapshotID, nil
+}
+
 // UserFollowsPlaylist checks if one or more (up to 5) Spotify users are following
 // a Spotify playlist, given the playlist's owner and ID.
 //

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -560,6 +560,20 @@ func TestReplacePlaylistTracksForbidden(t *testing.T) {
 	}
 }
 
+func TestReplacePlaylistItemsForbidden(t *testing.T) {
+	client, server := testClientString(http.StatusForbidden, "")
+	defer server.Close()
+
+	snapshot, err := client.ReplacePlaylistItems(context.Background(), "playlistID", "spotify:track:track1", "spotify:track:track2")
+	if err == nil {
+		t.Error("Replace succeeded but shouldn't have")
+	}
+
+	if snapshot != "" {
+		t.Fatal("Incorrect snapshot returned")
+	}
+}
+
 func TestReorderPlaylistRequest(t *testing.T) {
 	client, server := testClientString(http.StatusNotFound, "", func(req *http.Request) {
 		if ct := req.Header.Get("Content-Type"); ct != "application/json" {

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -536,6 +536,20 @@ func TestReplacePlaylistTracks(t *testing.T) {
 	}
 }
 
+func TestReplacePlaylistItems(t *testing.T) {
+	client, server := testClientString(http.StatusCreated, `{"snapshot_id": "test_snapshot"}`)
+	defer server.Close()
+
+	snapshot, err := client.ReplacePlaylistItems(context.Background(), "playlistID", "spotify:track:track1", "spotify:track:track2")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if snapshot != "test_snapshot" {
+		t.Fatal("Incorrect snapshot returned")
+	}
+}
+
 func TestReplacePlaylistTracksForbidden(t *testing.T) {
 	client, server := testClientString(http.StatusForbidden, "")
 	defer server.Close()

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -526,6 +526,96 @@ func TestRemoveTracksFromPlaylistOpt(t *testing.T) {
 	}
 }
 
+func TestClient_ReplacePlaylistItems(t *testing.T) {
+	type clientFields struct {
+		httpCode int
+		body     string
+	}
+	type args struct {
+		ctx        context.Context
+		playlistID ID
+		items      []URI
+	}
+	type want struct {
+		requestBody string
+		snapshot    string
+		err         string
+	}
+	tests := []struct {
+		name         string
+		clientFields clientFields
+		args         args
+		want         want
+	}{
+		{
+			name: "Happy path",
+			clientFields: clientFields{
+				httpCode: http.StatusCreated,
+				body:     `{"snapshot_id": "test_snapshot"}`,
+			},
+			args: args{
+				ctx:        context.TODO(),
+				playlistID: "playlistID",
+				items:      []URI{"spotify:track:track1", "spotify:track:track2"},
+			},
+			want: want{
+				requestBody: `{"uris":["spotify:track:track1","spotify:track:track2"]}`,
+				snapshot:    "test_snapshot",
+			},
+		}, {
+			name: "Forbidden",
+			clientFields: clientFields{
+				httpCode: http.StatusForbidden,
+			},
+			args: args{
+				ctx:        context.TODO(),
+				playlistID: "playlistID",
+				items:      []URI{"spotify:track:track1", "spotify:track:track2"},
+			},
+			want: want{
+				err: "spotify: HTTP 403: Forbidden (body empty)",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotRequestBody string
+
+			c, server := testClientString(tt.clientFields.httpCode, tt.clientFields.body, func(request *http.Request) {
+				b, err := ioutil.ReadAll(request.Body)
+				defer request.Body.Close()
+				if err != nil {
+					t.Error(err)
+				}
+
+				gotRequestBody = string(b)
+			})
+			defer server.Close()
+
+			gotSnapshot, gotErr := c.ReplacePlaylistItems(tt.args.ctx, tt.args.playlistID, tt.args.items...)
+			if tt.want.err != "" && gotErr == nil {
+				t.Errorf("Expected an error %s, got nil", tt.want.err)
+				return
+			}
+			if gotErr != nil {
+				if gotErr.Error() != tt.want.err {
+					t.Errorf("Expected error %s, got %s", tt.want.err, gotErr)
+				}
+
+				return
+			}
+
+			if gotSnapshot != tt.want.snapshot {
+				t.Errorf("Expected snapshot %s, got %s", tt.want.snapshot, gotSnapshot)
+			}
+
+			if gotRequestBody != tt.want.requestBody {
+				t.Errorf("Expected requestBody %s, got %s", tt.want.requestBody, gotRequestBody)
+			}
+		})
+	}
+}
+
 func TestReplacePlaylistTracks(t *testing.T) {
 	client, server := testClientString(http.StatusCreated, "")
 	defer server.Close()
@@ -536,35 +626,6 @@ func TestReplacePlaylistTracks(t *testing.T) {
 	}
 }
 
-func TestReplacePlaylistItems(t *testing.T) {
-	var body []byte
-
-	client, server := testClientString(http.StatusCreated, `{"snapshot_id": "test_snapshot"}`, func(request *http.Request) {
-		var err error
-		body, err = ioutil.ReadAll(request.Body)
-		defer request.Body.Close()
-		if err != nil {
-			t.Error(err)
-		}
-
-	})
-	defer server.Close()
-
-	snapshot, err := client.ReplacePlaylistItems(context.Background(), "playlistID", "spotify:track:track1", "spotify:track:track2")
-	if err != nil {
-		t.Error(err)
-	}
-
-	if snapshot != "test_snapshot" {
-		t.Error("Incorrect snapshot returned")
-	}
-
-	const expectedBody = `{"uris":["spotify:track:track1","spotify:track:track2"]}`
-	if string(body) != expectedBody {
-		t.Errorf("Expected '%s' as body, got %s", expectedBody, string(body))
-	}
-}
-
 func TestReplacePlaylistTracksForbidden(t *testing.T) {
 	client, server := testClientString(http.StatusForbidden, "")
 	defer server.Close()
@@ -572,20 +633,6 @@ func TestReplacePlaylistTracksForbidden(t *testing.T) {
 	err := client.ReplacePlaylistTracks(context.Background(), "playlistID", "track1", "track2")
 	if err == nil {
 		t.Error("Replace succeeded but shouldn't have")
-	}
-}
-
-func TestReplacePlaylistItemsForbidden(t *testing.T) {
-	client, server := testClientString(http.StatusForbidden, "")
-	defer server.Close()
-
-	snapshot, err := client.ReplacePlaylistItems(context.Background(), "playlistID", "spotify:track:track1", "spotify:track:track2")
-	if err == nil {
-		t.Error("Replace succeeded but shouldn't have")
-	}
-
-	if snapshot != "" {
-		t.Fatal("Incorrect snapshot returned")
 	}
 }
 

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -542,13 +542,7 @@ func TestReplacePlaylistItems(t *testing.T) {
 	client, server := testClientString(http.StatusCreated, `{"snapshot_id": "test_snapshot"}`, func(request *http.Request) {
 		var err error
 		body, err = ioutil.ReadAll(request.Body)
-		defer func() {
-			err := request.Body.Close()
-			if err != nil {
-				t.Error(err)
-			}
-		}()
-
+		defer request.Body.Close()
 		if err != nil {
 			t.Error(err)
 		}

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -565,8 +565,9 @@ func TestReplacePlaylistItems(t *testing.T) {
 		t.Error("Incorrect snapshot returned")
 	}
 
-	if string(body) != `{"uris":["spotify:track:track1","spotify:track:track2"]}` {
-		t.Errorf("Expected '{\"uris\":[\"spotify:track:track1\", \"spotify:track:track2\"]}' as body, got %s", string(body))
+	const expectedBody = `{"uris":["spotify:track:track1","spotify:track:track2"]}`
+	if string(body) != expectedBody {
+		t.Errorf("Expected '%s' as body, got %s", expectedBody, string(body))
 	}
 }
 

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -593,7 +593,7 @@ func TestClient_ReplacePlaylistItems(t *testing.T) {
 			defer server.Close()
 
 			gotSnapshot, gotErr := c.ReplacePlaylistItems(tt.args.ctx, tt.args.playlistID, tt.args.items...)
-			if tt.want.err != "" && gotErr == nil {
+			if gotErr == nil && tt.want.err != "" {
 				t.Errorf("Expected an error %s, got nil", tt.want.err)
 				return
 			}


### PR DESCRIPTION
Implementation of https://developer.spotify.com/documentation/web-api/reference/#/operations/reorder-or-replace-playlists-tracks replace functionality with URI's instead of trackID's