### PR TITLE
Add Description field to SimplePlaylist

### DIFF
--- a/playlist.go
+++ b/playlist.go
@@ -25,8 +25,10 @@ type PlaylistTracks struct {
 type SimplePlaylist struct {
 	// Indicates whether the playlist owner allows others to modify the playlist.
 	// Note: only non-collaborative playlists are currently returned by Spotify's Web API.
-	Collaborative bool              `json:"collaborative"`
-	ExternalURLs  map[string]string `json:"external_urls"`
+	Collaborative bool `json:"collaborative"`
+	// The playlist description. Empty string if no description is set.
+	Description  string            `json:"description"`
+	ExternalURLs map[string]string `json:"external_urls"`
 	// A link to the Web API endpoint providing full details of the playlist.
 	Endpoint string `json:"href"`
 	ID       ID     `json:"id"`
@@ -612,12 +614,12 @@ func (c *Client) UserFollowsPlaylist(ctx context.Context, playlistID ID, userIDs
 //
 // For example, in a playlist with 10 tracks, you can:
 //
-// - move the first track to the end of the playlist by setting
-//   RangeStart to 0 and InsertBefore to 10
-// - move the last track to the beginning of the playlist by setting
-//   RangeStart to 9 and InsertBefore to 0
-// - Move the last 2 tracks to the beginning of the playlist by setting
-//   RangeStart to 8 and RangeLength to 2.
+//   - move the first track to the end of the playlist by setting
+//     RangeStart to 0 and InsertBefore to 10
+//   - move the last track to the beginning of the playlist by setting
+//     RangeStart to 9 and InsertBefore to 0
+//   - Move the last 2 tracks to the beginning of the playlist by setting
+//     RangeStart to 8 and RangeLength to 2.
 type PlaylistReorderOptions struct {
 	// The position of the first track to be reordered.
 	// This field is required.

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -23,16 +23,21 @@ func TestFeaturedPlaylists(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	if msg != "Enjoy a mellow afternoon." {
+	if msg != "New Music Friday!" {
 		t.Errorf("Want 'Enjoy a mellow afternoon.', got'%s'\n", msg)
 	}
 	if p.Playlists == nil || len(p.Playlists) == 0 {
 		t.Fatal("Empty playlists result")
 	}
-	expected := "Hangover Friendly Singer-Songwriter"
+	expected := "New Music Friday Sweden"
 	if name := p.Playlists[0].Name; name != expected {
 		t.Errorf("Want '%s', got '%s'\n", expected, name)
 	}
+	expected = "Äntligen fredag och ny musik! Happy New Music Friday!"
+	if desc := p.Playlists[0].Description; desc != expected {
+		t.Errorf("Want '%s', got '%s'\n", expected, desc)
+	}
+
 }
 
 func TestFeaturedPlaylistsExpiredToken(t *testing.T) {
@@ -68,14 +73,22 @@ func TestPlaylistsForUser(t *testing.T) {
 	}
 	if l := len(playlists.Playlists); l == 0 {
 		t.Fatal("Didn't get any results")
+	} else if l != 7 {
+		t.Errorf("Got %d playlists, expected 7\n", l)
 	}
+
 	p := playlists.Playlists[0]
-	if p.Name != "Nederlandse Tipparade" {
-		t.Error("Expected Nederlandse Tipparade, got", p.Name)
+	if p.Name != "Top 40" {
+		t.Error("Expected Top 40, got", p.Name)
 	}
-	if p.Tracks.Total != 29 {
-		t.Error("Expected 29 tracks, got", p.Tracks.Total)
+	if p.Tracks.Total != 40 {
+		t.Error("Expected 40 tracks, got", p.Tracks.Total)
 	}
+	expected := "Nederlandse Top 40, de enige echte hitlijst van Nederland! Official Dutch Top 40. Check top40.nl voor alle details en luister iedere vrijdag vanaf 14.00 uur naar de lijst op Qmusic met Domien Verschuuren."
+	if p.Description != expected {
+		t.Errorf("Expected '%s', got '%s'\n", expected, p.Description)
+	}
+
 }
 
 func TestGetPlaylistOpt(t *testing.T) {
@@ -93,8 +106,9 @@ func TestGetPlaylistOpt(t *testing.T) {
 	if p.Description != "" {
 		t.Error("No description should be included")
 	}
-	if p.Tracks.Total != 10 {
-		t.Error("Expected 10 tracks")
+	// A bit counterintuitive, but we excluded tracks.total from the API call so it should be 0 in the model.
+	if p.Tracks.Total != 0 {
+		t.Errorf("Tracks.Total should be 0, got %d", p.Tracks.Total)
 	}
 }
 
@@ -116,17 +130,17 @@ func TestGetPlaylistTracks(t *testing.T) {
 	client, server := testClientFile(http.StatusOK, "test_data/playlist_tracks.txt")
 	defer server.Close()
 
-	tracks, err := client.GetPlaylistTracks(context.Background(), "playlistID")
+	tracks, err := client.GetPlaylistTracks(context.Background(), "5lH9NjOeJvctAO92ZrKQNB")
 	if err != nil {
 		t.Error(err)
 	}
-	if tracks.Total != 47 {
-		t.Errorf("Got %d tracks, expected 47\n", tracks.Total)
+	if tracks.Total != 40 {
+		t.Errorf("Got %d tracks, expected 40\n", tracks.Total)
 	}
 	if len(tracks.Tracks) == 0 {
 		t.Fatal("No tracks returned")
 	}
-	expected := "Time Of Our Lives"
+	expected := "Calm Down"
 	actual := tracks.Tracks[0].Track.Name
 	if expected != actual {
 		t.Errorf("Got '%s', expected '%s'\n", actual, expected)
@@ -136,8 +150,8 @@ func TestGetPlaylistTracks(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if f := tm.Format(DateLayout); f != "2014-11-25" {
-		t.Errorf("Expected added at 2014-11-25, got %s\n", f)
+	if f := tm.Format(DateLayout); f != "2022-07-15" {
+		t.Errorf("Expected added at 2022-07-15, got %s\n", f)
 	}
 }
 

--- a/test_data/current_users_playlists.txt
+++ b/test_data/current_users_playlists.txt
@@ -1,129 +1,198 @@
 {
-	"href": "https://api.spotify.com/v1/users/zbergquist99/playlists?offset=0&limit=20",
-	"items": [{
-		"collaborative": false,
-		"external_urls": {
-			"spotify": "http://open.spotify.com/user/spotifydiscover/playlist/49rgS5DAQGleEzLzgVN6PK"
-		},
-		"href": "https://api.spotify.com/v1/users/spotifydiscover/playlists/49rgS5DAQGleEzLzgVN6PK",
-		"id": "49rgS5DAQGleEzLzgVN6PK",
-		"images": [{
-			"height": 300,
-			"url": "https://i.scdn.co/image/8f5aaf6fed40ace25b38a62d62eaef5d4b788126",
-			"width": 300
-		}],
-		"name": "Discover Weekly",
-		"owner": {
-			"external_urls": {
-				"spotify": "http://open.spotify.com/user/spotifydiscover"
-			},
-			"href": "https://api.spotify.com/v1/users/spotifydiscover",
-			"id": "spotifydiscover",
-			"type": "user",
-			"uri": "spotify:user:spotifydiscover"
-		},
-		"public": false,
-		"snapshot_id": "tk3IF4Uksr76l3spVkCqtci3OJ4T98ijvh2zuzidrtbSwJhVn9HFdILnF6BVCxJU",
-		"tracks": {
-			"href": "https://api.spotify.com/v1/users/spotifydiscover/playlists/49rgS5DAQGleEzLzgVN6PK/tracks",
-			"total": 30
-		},
-		"type": "playlist",
-		"uri": "spotify:user:spotifydiscover:playlist:49rgS5DAQGleEzLzgVN6PK"
-	}, {
-		"collaborative": false,
-		"external_urls": {
-			"spotify": "http://open.spotify.com/user/spotify/playlist/4BKT5olNFqLB1FAa8OtC8k"
-		},
-		"href": "https://api.spotify.com/v1/users/spotify/playlists/4BKT5olNFqLB1FAa8OtC8k",
-		"id": "4BKT5olNFqLB1FAa8OtC8k",
-		"images": [{
-			"height": 300,
-			"url": "https://i.scdn.co/image/dde0c0ca2931038a00c22f5b0750fd38335bdeff",
-			"width": 300
-		}],
-		"name": "Your Favorite Coffeehouse",
-		"owner": {
-			"external_urls": {
-				"spotify": "http://open.spotify.com/user/spotify"
-			},
-			"href": "https://api.spotify.com/v1/users/spotify",
-			"id": "spotify",
-			"type": "user",
-			"uri": "spotify:user:spotify"
-		},
-		"public": false,
-		"snapshot_id": "12QhxYHYdEJmkz54dlDciQbPgwFhHJrXKTUHm1DN2+2JLS2zPr1F/eDcIYJU3Py9",
-		"tracks": {
-			"href": "https://api.spotify.com/v1/users/spotify/playlists/4BKT5olNFqLB1FAa8OtC8k/tracks",
-			"total": 69
-		},
-		"type": "playlist",
-		"uri": "spotify:user:spotify:playlist:4BKT5olNFqLB1FAa8OtC8k"
-	}, {
-		"collaborative": false,
-		"external_urls": {
-			"spotify": "http://open.spotify.com/user/spotify/playlist/16BpjqQV1Ey0HeDueNDSYz"
-		},
-		"href": "https://api.spotify.com/v1/users/spotify/playlists/16BpjqQV1Ey0HeDueNDSYz",
-		"id": "16BpjqQV1Ey0HeDueNDSYz",
-		"images": [{
-			"height": 300,
-			"url": "https://i.scdn.co/image/6b282f0ad7f5de8c8f04a20268376be638e8241a",
-			"width": 300
-		}],
-		"name": "Afternoon Acoustic",
-		"owner": {
-			"external_urls": {
-				"spotify": "http://open.spotify.com/user/spotify"
-			},
-			"href": "https://api.spotify.com/v1/users/spotify",
-			"id": "spotify",
-			"type": "user",
-			"uri": "spotify:user:spotify"
-		},
-		"public": false,
-		"snapshot_id": "+BmVMef6WTYmcU1IJWJjPgbmlcKaKPLNVS82ei/NXyWmVAJx4hIMmvKptafWkYVb",
-		"tracks": {
-			"href": "https://api.spotify.com/v1/users/spotify/playlists/16BpjqQV1Ey0HeDueNDSYz/tracks",
-			"total": 99
-		},
-		"type": "playlist",
-		"uri": "spotify:user:spotify:playlist:16BpjqQV1Ey0HeDueNDSYz"
-	}, {
-		"collaborative": false,
-		"external_urls": {
-			"spotify": "http://open.spotify.com/user/spotify_uk_/playlist/00XAjSa5jB0MNX56tIKMq0"
-		},
-		"href": "https://api.spotify.com/v1/users/spotify_uk_/playlists/00XAjSa5jB0MNX56tIKMq0",
-		"id": "00XAjSa5jB0MNX56tIKMq0",
-		"images": [{
-			"height": 300,
-			"url": "https://i.scdn.co/image/cbca878ec842b14821604767ff745feb1a0f6130",
-			"width": 300
-		}],
-		"name": "Yoga and Meditation",
-		"owner": {
-			"external_urls": {
-				"spotify": "http://open.spotify.com/user/spotify_uk_"
-			},
-			"href": "https://api.spotify.com/v1/users/spotify_uk_",
-			"id": "spotify_uk_",
-			"type": "user",
-			"uri": "spotify:user:spotify_uk_"
-		},
-		"public": true,
-		"snapshot_id": "Y+IT9jxMArqInFKtUUgZfUHGNg+4ZZ9EyKOkhqwwqEJ6BHAHiHmI8urIpIeYGzAd",
-		"tracks": {
-			"href": "https://api.spotify.com/v1/users/spotify_uk_/playlists/00XAjSa5jB0MNX56tIKMq0/tracks",
-			"total": 31
-		},
-		"type": "playlist",
-		"uri": "spotify:user:spotify_uk_:playlist:00XAjSa5jB0MNX56tIKMq0"
-	}],
-	"limit": 20,
-	"next": null,
-	"offset": 0,
-	"previous": null,
-	"total": 4
+  "href" : "https://api.spotify.com/v1/users/1123408718/playlists?offset=20&limit=5",
+  "items" : [ {
+    "collaborative" : false,
+    "description" : "",
+    "external_urls" : {
+      "spotify" : "https://open.spotify.com/playlist/3sPyrAW9PVUMxL9i6QFbaV"
+    },
+    "href" : "https://api.spotify.com/v1/playlists/3sPyrAW9PVUMxL9i6QFbaV",
+    "id" : "3sPyrAW9PVUMxL9i6QFbaV",
+    "images" : [ {
+      "height" : 640,
+      "url" : "https://i.scdn.co/image/ab67616d0000b273a72b5360c8941c819162dbb9",
+      "width" : 640
+    } ],
+    "name" : "Core",
+    "owner" : {
+      "display_name" : "Antoine Egea",
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/1123408718"
+      },
+      "href" : "https://api.spotify.com/v1/users/1123408718",
+      "id" : "1123408718",
+      "type" : "user",
+      "uri" : "spotify:user:1123408718"
+    },
+    "primary_color" : null,
+    "public" : true,
+    "snapshot_id" : "NSw5ZTBhOGQ5M2JkMWM1NDViMWI2YjBiZDcyOTE0NzE0Nzg4MWY0NmNm",
+    "tracks" : {
+      "href" : "https://api.spotify.com/v1/playlists/3sPyrAW9PVUMxL9i6QFbaV/tracks",
+      "total" : 3
+    },
+    "type" : "playlist",
+    "uri" : "spotify:playlist:3sPyrAW9PVUMxL9i6QFbaV"
+  }, {
+    "collaborative" : false,
+    "description" : "This is kinda fuzzy",
+    "external_urls" : {
+      "spotify" : "https://open.spotify.com/playlist/1hronnZ0DOUXcMna7JtgaN"
+    },
+    "href" : "https://api.spotify.com/v1/playlists/1hronnZ0DOUXcMna7JtgaN",
+    "id" : "1hronnZ0DOUXcMna7JtgaN",
+    "images" : [ {
+      "height" : 640,
+      "url" : "https://mosaic.scdn.co/640/ab67616d0000b273180987ab035f6ae9d4459415ab67616d0000b27360c94ef7cdb9d4e5802a0f1eab67616d0000b273995f332b8606a590bcab77e3ab67616d0000b273fa8ec1b4b7b971f05e7554ec",
+      "width" : 640
+    }, {
+      "height" : 300,
+      "url" : "https://mosaic.scdn.co/300/ab67616d0000b273180987ab035f6ae9d4459415ab67616d0000b27360c94ef7cdb9d4e5802a0f1eab67616d0000b273995f332b8606a590bcab77e3ab67616d0000b273fa8ec1b4b7b971f05e7554ec",
+      "width" : 300
+    }, {
+      "height" : 60,
+      "url" : "https://mosaic.scdn.co/60/ab67616d0000b273180987ab035f6ae9d4459415ab67616d0000b27360c94ef7cdb9d4e5802a0f1eab67616d0000b273995f332b8606a590bcab77e3ab67616d0000b273fa8ec1b4b7b971f05e7554ec",
+      "width" : 60
+    } ],
+    "name" : "Black/Atmo/Prog ?",
+    "owner" : {
+      "display_name" : "Antoine Egea",
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/1123408718"
+      },
+      "href" : "https://api.spotify.com/v1/users/1123408718",
+      "id" : "1123408718",
+      "type" : "user",
+      "uri" : "spotify:user:1123408718"
+    },
+    "primary_color" : null,
+    "public" : true,
+    "snapshot_id" : "MTUsNDAyOTY5ZjNiNTZlZjIzNWYwYzNhMDc2ZTc5NzI4OTI2OGM5YmJlNg==",
+    "tracks" : {
+      "href" : "https://api.spotify.com/v1/playlists/1hronnZ0DOUXcMna7JtgaN/tracks",
+      "total" : 10
+    },
+    "type" : "playlist",
+    "uri" : "spotify:playlist:1hronnZ0DOUXcMna7JtgaN"
+  }, {
+    "collaborative" : false,
+    "description" : "",
+    "external_urls" : {
+      "spotify" : "https://open.spotify.com/playlist/46TfdmGiWxxX4uZzqohw89"
+    },
+    "href" : "https://api.spotify.com/v1/playlists/46TfdmGiWxxX4uZzqohw89",
+    "id" : "46TfdmGiWxxX4uZzqohw89",
+    "images" : [ {
+      "height" : 640,
+      "url" : "https://mosaic.scdn.co/640/ab67616d0000b273050bed1b11fc76c5a2cd9894ab67616d0000b27346e1dbefaba153a4e5434028ab67616d0000b273a17193d8fb64738c029d8569ab67616d0000b273c40666f47d225dee6e28a6dd",
+      "width" : 640
+    }, {
+      "height" : 300,
+      "url" : "https://mosaic.scdn.co/300/ab67616d0000b273050bed1b11fc76c5a2cd9894ab67616d0000b27346e1dbefaba153a4e5434028ab67616d0000b273a17193d8fb64738c029d8569ab67616d0000b273c40666f47d225dee6e28a6dd",
+      "width" : 300
+    }, {
+      "height" : 60,
+      "url" : "https://mosaic.scdn.co/60/ab67616d0000b273050bed1b11fc76c5a2cd9894ab67616d0000b27346e1dbefaba153a4e5434028ab67616d0000b273a17193d8fb64738c029d8569ab67616d0000b273c40666f47d225dee6e28a6dd",
+      "width" : 60
+    } ],
+    "name" : "Troll",
+    "owner" : {
+      "display_name" : "Antoine Egea",
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/1123408718"
+      },
+      "href" : "https://api.spotify.com/v1/users/1123408718",
+      "id" : "1123408718",
+      "type" : "user",
+      "uri" : "spotify:user:1123408718"
+    },
+    "primary_color" : null,
+    "public" : false,
+    "snapshot_id" : "MTIsNzk4ZWUwMWM4Zjg1MDY0MDgyODBlZmEzMDFkOTlhZTUwYmM3ZDkwZg==",
+    "tracks" : {
+      "href" : "https://api.spotify.com/v1/playlists/46TfdmGiWxxX4uZzqohw89/tracks",
+      "total" : 7
+    },
+    "type" : "playlist",
+    "uri" : "spotify:playlist:46TfdmGiWxxX4uZzqohw89"
+  }, {
+    "collaborative" : false,
+    "description" : "",
+    "external_urls" : {
+      "spotify" : "https://open.spotify.com/playlist/01ckpilMpZMY54FNOmM6hx"
+    },
+    "href" : "https://api.spotify.com/v1/playlists/01ckpilMpZMY54FNOmM6hx",
+    "id" : "01ckpilMpZMY54FNOmM6hx",
+    "images" : [ {
+      "height" : 640,
+      "url" : "https://i.scdn.co/image/ab67616d0000b2739dc01ddb0924158d64a283cd",
+      "width" : 640
+    } ],
+    "name" : "Melomiel",
+    "owner" : {
+      "display_name" : "Antoine Egea",
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/1123408718"
+      },
+      "href" : "https://api.spotify.com/v1/users/1123408718",
+      "id" : "1123408718",
+      "type" : "user",
+      "uri" : "spotify:user:1123408718"
+    },
+    "primary_color" : null,
+    "public" : true,
+    "snapshot_id" : "OSw0OWMxZjMxNDAwMjM0ODk5NTE0MTlkMTNlM2UzYzA5NzllZTU2ZjI0",
+    "tracks" : {
+      "href" : "https://api.spotify.com/v1/playlists/01ckpilMpZMY54FNOmM6hx/tracks",
+      "total" : 3
+    },
+    "type" : "playlist",
+    "uri" : "spotify:playlist:01ckpilMpZMY54FNOmM6hx"
+  }, {
+    "collaborative" : false,
+    "description" : "Deathcore,techdeath, tout ce qui tape plus fort que du melodeath",
+    "external_urls" : {
+      "spotify" : "https://open.spotify.com/playlist/19DESVha4FbNzqQfcGXMjc"
+    },
+    "href" : "https://api.spotify.com/v1/playlists/19DESVha4FbNzqQfcGXMjc",
+    "id" : "19DESVha4FbNzqQfcGXMjc",
+    "images" : [ {
+      "height" : 640,
+      "url" : "https://mosaic.scdn.co/640/ab67616d0000b2731686d2714fcf32b3adac69b7ab67616d0000b2734dc23798ad18d00c2f365a91ab67616d0000b273765da70d8fc8cc47dfad0829ab67616d0000b27378beadb1f83bfb73e17b4af6",
+      "width" : 640
+    }, {
+      "height" : 300,
+      "url" : "https://mosaic.scdn.co/300/ab67616d0000b2731686d2714fcf32b3adac69b7ab67616d0000b2734dc23798ad18d00c2f365a91ab67616d0000b273765da70d8fc8cc47dfad0829ab67616d0000b27378beadb1f83bfb73e17b4af6",
+      "width" : 300
+    }, {
+      "height" : 60,
+      "url" : "https://mosaic.scdn.co/60/ab67616d0000b2731686d2714fcf32b3adac69b7ab67616d0000b2734dc23798ad18d00c2f365a91ab67616d0000b273765da70d8fc8cc47dfad0829ab67616d0000b27378beadb1f83bfb73e17b4af6",
+      "width" : 60
+    } ],
+    "name" : "HEAVY MIEL",
+    "owner" : {
+      "display_name" : "Antoine Egea",
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/1123408718"
+      },
+      "href" : "https://api.spotify.com/v1/users/1123408718",
+      "id" : "1123408718",
+      "type" : "user",
+      "uri" : "spotify:user:1123408718"
+    },
+    "primary_color" : null,
+    "public" : true,
+    "snapshot_id" : "MTgsMTE3NDA3N2VjNzA5ZDBkNzJjMDA1MDk4YjBlNDRjOTkzZTZiNDRkMg==",
+    "tracks" : {
+      "href" : "https://api.spotify.com/v1/playlists/19DESVha4FbNzqQfcGXMjc/tracks",
+      "total" : 10
+    },
+    "type" : "playlist",
+    "uri" : "spotify:playlist:19DESVha4FbNzqQfcGXMjc"
+  } ],
+  "limit" : 5,
+  "next" : "https://api.spotify.com/v1/users/1123408718/playlists?offset=25&limit=5",
+  "offset" : 20,
+  "previous" : "https://api.spotify.com/v1/users/1123408718/playlists?offset=15&limit=5",
+  "total" : 42
 }

--- a/test_data/featured_playlists.txt
+++ b/test_data/featured_playlists.txt
@@ -1,334 +1,175 @@
 {
-  "message" : "Enjoy a mellow afternoon.",
+  "message" : "New Music Friday!",
   "playlists" : {
-    "href" : "https://api.spotify.com/v1/browse/featured-playlists?country=SE&timestamp=2015-01-25T16:47:34&offset=0&limit=20",
+    "href" : "https://api.spotify.com/v1/browse/featured-playlists?country=SE&timestamp=2022-09-16T14%3A42%3A13&offset=0&limit=5",
     "items" : [ {
       "collaborative" : false,
+      "description" : "Äntligen fredag och ny musik! Happy New Music Friday!",
       "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/spotify/playlist/5mYuqPUConqYzvTA0IGibc"
+        "spotify" : "https://open.spotify.com/playlist/37i9dQZF1DXcecv7ESbOPu"
       },
-      "href" : "https://api.spotify.com/v1/users/spotify/playlists/5mYuqPUConqYzvTA0IGibc",
-      "id" : "5mYuqPUConqYzvTA0IGibc",
+      "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DXcecv7ESbOPu",
+      "id" : "37i9dQZF1DXcecv7ESbOPu",
       "images" : [ {
-        "url" : "https://i.scdn.co/image/89c8ce91851e4f4c9d6312c6012bbc62f19c5459"
+        "height" : null,
+        "url" : "https://i.scdn.co/image/ab67706f00000003069a4dce1724d0b60dc6c5b5",
+        "width" : null
       } ],
-      "name" : "Hangover Friendly Singer-Songwriter",
+      "name" : "New Music Friday Sweden",
       "owner" : {
+        "display_name" : "Spotify",
         "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/spotify"
+          "spotify" : "https://open.spotify.com/user/spotify"
         },
         "href" : "https://api.spotify.com/v1/users/spotify",
         "id" : "spotify",
         "type" : "user",
         "uri" : "spotify:user:spotify"
       },
+      "primary_color" : null,
       "public" : null,
+      "snapshot_id" : "MTY2MzI3OTIwMCwwMDAwMDAwMDRjMGYyYjU2ZDkyMjE1YjM5ZDc0MzBmNTc0NzBjZmFj",
       "tracks" : {
-        "href" : "https://api.spotify.com/v1/users/spotify/playlists/5mYuqPUConqYzvTA0IGibc/tracks",
-        "total" : 86
+        "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DXcecv7ESbOPu/tracks",
+        "total" : 104
       },
       "type" : "playlist",
-      "uri" : "spotify:user:spotify:playlist:5mYuqPUConqYzvTA0IGibc"
+      "uri" : "spotify:playlist:37i9dQZF1DXcecv7ESbOPu"
     }, {
       "collaborative" : false,
+      "description" : "Håll det 100.",
       "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/spotify/playlist/0sMRTIZrf9NdwDboJUztZn"
+        "spotify" : "https://open.spotify.com/playlist/37i9dQZF1DWXfgo3OOonqa"
       },
-      "href" : "https://api.spotify.com/v1/users/spotify/playlists/0sMRTIZrf9NdwDboJUztZn",
-      "id" : "0sMRTIZrf9NdwDboJUztZn",
+      "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DWXfgo3OOonqa",
+      "id" : "37i9dQZF1DWXfgo3OOonqa",
       "images" : [ {
-        "url" : "https://i.scdn.co/image/1803a515338ed2685d0c89347b6250c2392ad2da"
+        "height" : null,
+        "url" : "https://i.scdn.co/image/ab67706f0000000309c36c4c0a32a14e0caa5f40",
+        "width" : null
       } ],
-      "name" : "Sunday Stroll",
+      "name" : "100",
       "owner" : {
+        "display_name" : "Spotify",
         "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/spotify"
+          "spotify" : "https://open.spotify.com/user/spotify"
         },
         "href" : "https://api.spotify.com/v1/users/spotify",
         "id" : "spotify",
         "type" : "user",
         "uri" : "spotify:user:spotify"
       },
+      "primary_color" : null,
       "public" : null,
+      "snapshot_id" : "MTY2MzI3OTIwMCwwMDAwMDAwMGQ2OTAzNDE4OTkzMWQ5ZTVlNzM3YTk1YTJjZjc3YmY5",
       "tracks" : {
-        "href" : "https://api.spotify.com/v1/users/spotify/playlists/0sMRTIZrf9NdwDboJUztZn/tracks",
+        "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DWXfgo3OOonqa/tracks",
+        "total" : 85
+      },
+      "type" : "playlist",
+      "uri" : "spotify:playlist:37i9dQZF1DWXfgo3OOonqa"
+    }, {
+      "collaborative" : false,
+      "description" : "De senaste hitsen du behöver ha koll på.",
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/playlist/37i9dQZF1DXc4CrXgl8cum"
+      },
+      "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DXc4CrXgl8cum",
+      "id" : "37i9dQZF1DXc4CrXgl8cum",
+      "images" : [ {
+        "height" : null,
+        "url" : "https://i.scdn.co/image/ab67706f0000000356e636fd84c35d13d2d66144",
+        "width" : null
+      } ],
+      "name" : "Get Your Hits Together",
+      "owner" : {
+        "display_name" : "Spotify",
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/user/spotify"
+        },
+        "href" : "https://api.spotify.com/v1/users/spotify",
+        "id" : "spotify",
+        "type" : "user",
+        "uri" : "spotify:user:spotify"
+      },
+      "primary_color" : null,
+      "public" : null,
+      "snapshot_id" : "MTY2MzI3OTIwMCwwMDAwMDAwMGQ1NmM3MzJkOWM4MjRkODE1ZjI3ODk4MTEyNWUzMWEw",
+      "tracks" : {
+        "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DXc4CrXgl8cum/tracks",
+        "total" : 80
+      },
+      "type" : "playlist",
+      "uri" : "spotify:playlist:37i9dQZF1DXc4CrXgl8cum"
+    }, {
+      "collaborative" : false,
+      "description" : "Det bästa från svensk & internationell pop.",
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/playlist/37i9dQZF1DX7FV7CCq9byu"
+      },
+      "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DX7FV7CCq9byu",
+      "id" : "37i9dQZF1DX7FV7CCq9byu",
+      "images" : [ {
+        "height" : null,
+        "url" : "https://i.scdn.co/image/ab67706f0000000392ddd597502b989975648e78",
+        "width" : null
+      } ],
+      "name" : "Ny Pop",
+      "owner" : {
+        "display_name" : "Spotify",
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/user/spotify"
+        },
+        "href" : "https://api.spotify.com/v1/users/spotify",
+        "id" : "spotify",
+        "type" : "user",
+        "uri" : "spotify:user:spotify"
+      },
+      "primary_color" : null,
+      "public" : null,
+      "snapshot_id" : "MTY2MzI3OTIwMCwwMDAwMDAwMGU3ZjlhMDE3NDgyNjQ3ZjhmOTMxZDM5YWY2ODcxM2Fk",
+      "tracks" : {
+        "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DX7FV7CCq9byu/tracks",
         "total" : 70
       },
       "type" : "playlist",
-      "uri" : "spotify:user:spotify:playlist:0sMRTIZrf9NdwDboJUztZn"
+      "uri" : "spotify:playlist:37i9dQZF1DX7FV7CCq9byu"
     }, {
       "collaborative" : false,
+      "description" : "Den bästa och största rocklistan i Sverige! Cover: Ghost",
       "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/spotify/playlist/177ddWh0FuKFgzrl5D57Md"
+        "spotify" : "https://open.spotify.com/playlist/37i9dQZF1DXdiF2k2CLnQA"
       },
-      "href" : "https://api.spotify.com/v1/users/spotify/playlists/177ddWh0FuKFgzrl5D57Md",
-      "id" : "177ddWh0FuKFgzrl5D57Md",
+      "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DXdiF2k2CLnQA",
+      "id" : "37i9dQZF1DXdiF2k2CLnQA",
       "images" : [ {
-        "url" : "https://i.scdn.co/image/152b9abfe38a528c1b7d353b3def1e21c6aacb5c"
+        "height" : null,
+        "url" : "https://i.scdn.co/image/ab67706f00000003d11908425d4ea65f01f87e29",
+        "width" : null
       } ],
-      "name" : "Indie Brunch",
+      "name" : "VOLUME SWEDEN",
       "owner" : {
+        "display_name" : "Spotify",
         "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/spotify"
+          "spotify" : "https://open.spotify.com/user/spotify"
         },
         "href" : "https://api.spotify.com/v1/users/spotify",
         "id" : "spotify",
         "type" : "user",
         "uri" : "spotify:user:spotify"
       },
+      "primary_color" : null,
       "public" : null,
+      "snapshot_id" : "MTY2MzI3OTIwMCwwMDAwMDAwMDBlNzdlZTRjNTY1NTFhY2JjMGM2OTUwMThjOGQ5NzQ0",
       "tracks" : {
-        "href" : "https://api.spotify.com/v1/users/spotify/playlists/177ddWh0FuKFgzrl5D57Md/tracks",
-        "total" : 51
+        "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DXdiF2k2CLnQA/tracks",
+        "total" : 80
       },
       "type" : "playlist",
-      "uri" : "spotify:user:spotify:playlist:177ddWh0FuKFgzrl5D57Md"
-    }, {
-      "collaborative" : false,
-      "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/spotify/playlist/4wtLaWQcPct5tlAWTxqjMD"
-      },
-      "href" : "https://api.spotify.com/v1/users/spotify/playlists/4wtLaWQcPct5tlAWTxqjMD",
-      "id" : "4wtLaWQcPct5tlAWTxqjMD",
-      "images" : [ {
-        "url" : "https://i.scdn.co/image/f005b8105b1a4db1dbfa07f9d721570f740573ed"
-      } ],
-      "name" : "The Happy Hipster",
-      "owner" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/spotify"
-        },
-        "href" : "https://api.spotify.com/v1/users/spotify",
-        "id" : "spotify",
-        "type" : "user",
-        "uri" : "spotify:user:spotify"
-      },
-      "public" : null,
-      "tracks" : {
-        "href" : "https://api.spotify.com/v1/users/spotify/playlists/4wtLaWQcPct5tlAWTxqjMD/tracks",
-        "total" : 176
-      },
-      "type" : "playlist",
-      "uri" : "spotify:user:spotify:playlist:4wtLaWQcPct5tlAWTxqjMD"
-    }, {
-      "collaborative" : false,
-      "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/spotify/playlist/0i0KOEPUK7pA1A5A29ulk4"
-      },
-      "href" : "https://api.spotify.com/v1/users/spotify/playlists/0i0KOEPUK7pA1A5A29ulk4",
-      "id" : "0i0KOEPUK7pA1A5A29ulk4",
-      "images" : [ {
-        "url" : "https://i.scdn.co/image/a2391ed5622b7954583699ea882b265eb64ba72b"
-      } ],
-      "name" : "Hanging Out and Relaxing",
-      "owner" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/spotify"
-        },
-        "href" : "https://api.spotify.com/v1/users/spotify",
-        "id" : "spotify",
-        "type" : "user",
-        "uri" : "spotify:user:spotify"
-      },
-      "public" : null,
-      "tracks" : {
-        "href" : "https://api.spotify.com/v1/users/spotify/playlists/0i0KOEPUK7pA1A5A29ulk4/tracks",
-        "total" : 88
-      },
-      "type" : "playlist",
-      "uri" : "spotify:user:spotify:playlist:0i0KOEPUK7pA1A5A29ulk4"
-    }, {
-      "collaborative" : false,
-      "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/spotify/playlist/5xtPbr795elinw40DsMnTY"
-      },
-      "href" : "https://api.spotify.com/v1/users/spotify/playlists/5xtPbr795elinw40DsMnTY",
-      "id" : "5xtPbr795elinw40DsMnTY",
-      "images" : [ {
-        "url" : "https://i.scdn.co/image/cee27f2c683224f53494e0c2e434461fb140c6ff"
-      } ],
-      "name" : "Indie Workout",
-      "owner" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/spotify"
-        },
-        "href" : "https://api.spotify.com/v1/users/spotify",
-        "id" : "spotify",
-        "type" : "user",
-        "uri" : "spotify:user:spotify"
-      },
-      "public" : null,
-      "tracks" : {
-        "href" : "https://api.spotify.com/v1/users/spotify/playlists/5xtPbr795elinw40DsMnTY/tracks",
-        "total" : 265
-      },
-      "type" : "playlist",
-      "uri" : "spotify:user:spotify:playlist:5xtPbr795elinw40DsMnTY"
-    }, {
-      "collaborative" : false,
-      "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/spotify/playlist/2KhnhTzEbZYCSz0ljMgQSn"
-      },
-      "href" : "https://api.spotify.com/v1/users/spotify/playlists/2KhnhTzEbZYCSz0ljMgQSn",
-      "id" : "2KhnhTzEbZYCSz0ljMgQSn",
-      "images" : [ {
-        "url" : "https://i.scdn.co/image/355110a31e65ca349da491d3c9dfb8351c8d80ea"
-      } ],
-      "name" : "Lazy Weekend",
-      "owner" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/spotify"
-        },
-        "href" : "https://api.spotify.com/v1/users/spotify",
-        "id" : "spotify",
-        "type" : "user",
-        "uri" : "spotify:user:spotify"
-      },
-      "public" : null,
-      "tracks" : {
-        "href" : "https://api.spotify.com/v1/users/spotify/playlists/2KhnhTzEbZYCSz0ljMgQSn/tracks",
-        "total" : 217
-      },
-      "type" : "playlist",
-      "uri" : "spotify:user:spotify:playlist:2KhnhTzEbZYCSz0ljMgQSn"
-    }, {
-      "collaborative" : false,
-      "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/spotify/playlist/2i0HbrNwqR7TTHFFet80W6"
-      },
-      "href" : "https://api.spotify.com/v1/users/spotify/playlists/2i0HbrNwqR7TTHFFet80W6",
-      "id" : "2i0HbrNwqR7TTHFFet80W6",
-      "images" : [ {
-        "url" : "https://i.scdn.co/image/e0fdde70966dbcf7fa1c8dd265908c2418f24702"
-      } ],
-      "name" : "Sunday Drive",
-      "owner" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/spotify"
-        },
-        "href" : "https://api.spotify.com/v1/users/spotify",
-        "id" : "spotify",
-        "type" : "user",
-        "uri" : "spotify:user:spotify"
-      },
-      "public" : null,
-      "tracks" : {
-        "href" : "https://api.spotify.com/v1/users/spotify/playlists/2i0HbrNwqR7TTHFFet80W6/tracks",
-        "total" : 50
-      },
-      "type" : "playlist",
-      "uri" : "spotify:user:spotify:playlist:2i0HbrNwqR7TTHFFet80W6"
-    }, {
-      "collaborative" : false,
-      "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/spotify/playlist/4MNCftvCERT8MreHSpoRPe"
-      },
-      "href" : "https://api.spotify.com/v1/users/spotify/playlists/4MNCftvCERT8MreHSpoRPe",
-      "id" : "4MNCftvCERT8MreHSpoRPe",
-      "images" : [ {
-        "url" : "https://i.scdn.co/image/5d5a91e82a84ed96042151371998d60d6a37d7bc"
-      } ],
-      "name" : "Soft Pop Hits",
-      "owner" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/spotify"
-        },
-        "href" : "https://api.spotify.com/v1/users/spotify",
-        "id" : "spotify",
-        "type" : "user",
-        "uri" : "spotify:user:spotify"
-      },
-      "public" : null,
-      "tracks" : {
-        "href" : "https://api.spotify.com/v1/users/spotify/playlists/4MNCftvCERT8MreHSpoRPe/tracks",
-        "total" : 180
-      },
-      "type" : "playlist",
-      "uri" : "spotify:user:spotify:playlist:4MNCftvCERT8MreHSpoRPe"
-    }, {
-      "collaborative" : false,
-      "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/spotify/playlist/7C49D2hDFRiWLcyFL8oCWN"
-      },
-      "href" : "https://api.spotify.com/v1/users/spotify/playlists/7C49D2hDFRiWLcyFL8oCWN",
-      "id" : "7C49D2hDFRiWLcyFL8oCWN",
-      "images" : [ {
-        "url" : "https://i.scdn.co/image/c585c533463ef8abd4a5f6dc8490b7304f0835cd"
-      } ],
-      "name" : "An Instrumental Sunday",
-      "owner" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/spotify"
-        },
-        "href" : "https://api.spotify.com/v1/users/spotify",
-        "id" : "spotify",
-        "type" : "user",
-        "uri" : "spotify:user:spotify"
-      },
-      "public" : null,
-      "tracks" : {
-        "href" : "https://api.spotify.com/v1/users/spotify/playlists/7C49D2hDFRiWLcyFL8oCWN/tracks",
-        "total" : 48
-      },
-      "type" : "playlist",
-      "uri" : "spotify:user:spotify:playlist:7C49D2hDFRiWLcyFL8oCWN"
-    }, {
-      "collaborative" : false,
-      "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/spotify/playlist/6VFQeQWFz2WgvSZrpJ7uuy"
-      },
-      "href" : "https://api.spotify.com/v1/users/spotify/playlists/6VFQeQWFz2WgvSZrpJ7uuy",
-      "id" : "6VFQeQWFz2WgvSZrpJ7uuy",
-      "images" : [ {
-        "url" : "https://i.scdn.co/image/b52458df211366cd847207deace31461d6b2abee"
-      } ],
-      "name" : "R&B Love",
-      "owner" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/spotify"
-        },
-        "href" : "https://api.spotify.com/v1/users/spotify",
-        "id" : "spotify",
-        "type" : "user",
-        "uri" : "spotify:user:spotify"
-      },
-      "public" : null,
-      "tracks" : {
-        "href" : "https://api.spotify.com/v1/users/spotify/playlists/6VFQeQWFz2WgvSZrpJ7uuy/tracks",
-        "total" : 168
-      },
-      "type" : "playlist",
-      "uri" : "spotify:user:spotify:playlist:6VFQeQWFz2WgvSZrpJ7uuy"
-    }, {
-      "collaborative" : false,
-      "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/spotify/playlist/570tVSLPdLnRU0z0bqd8Wk"
-      },
-      "href" : "https://api.spotify.com/v1/users/spotify/playlists/570tVSLPdLnRU0z0bqd8Wk",
-      "id" : "570tVSLPdLnRU0z0bqd8Wk",
-      "images" : [ {
-        "url" : "https://i.scdn.co/image/34b68da3e74632592dd864f9e38e7e062d063054"
-      } ],
-      "name" : "Women of Jazz",
-      "owner" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/spotify"
-        },
-        "href" : "https://api.spotify.com/v1/users/spotify",
-        "id" : "spotify",
-        "type" : "user",
-        "uri" : "spotify:user:spotify"
-      },
-      "public" : null,
-      "tracks" : {
-        "href" : "https://api.spotify.com/v1/users/spotify/playlists/570tVSLPdLnRU0z0bqd8Wk/tracks",
-        "total" : 72
-      },
-      "type" : "playlist",
-      "uri" : "spotify:user:spotify:playlist:570tVSLPdLnRU0z0bqd8Wk"
+      "uri" : "spotify:playlist:37i9dQZF1DXdiF2k2CLnQA"
     } ],
-    "limit" : 20,
-    "next" : null,
+    "limit" : 5,
+    "next" : "https://api.spotify.com/v1/browse/featured-playlists?country=SE&timestamp=2022-09-16T14%3A42%3A13&offset=5&limit=5",
     "offset" : 0,
     "previous" : null,
     "total" : 12

--- a/test_data/get_playlist_opt.txt
+++ b/test_data/get_playlist_opt.txt
@@ -1,701 +1,493 @@
 {
-  "collaborative" : false,
-  "description" : null,
-  "external_urls" : {
-    "spotify" : "http://open.spotify.com/user/zbergquist99/playlist/7I6yjOAxMq4qsvzgqxw7aU"
-  },
-  "followers" : {
-    "href" : null,
-    "total" : 0
-  },
-  "href" : "https://api.spotify.com/v1/users/zbergquist99/playlists/7I6yjOAxMq4qsvzgqxw7aU?fields=fields=href,name,owner(!href,external_urls),tracks.items(added_by.id,track(name,href,album(name,href)))",
-  "id" : "7I6yjOAxMq4qsvzgqxw7aU",
-  "images" : [ {
-    "height" : 640,
-    "url" : "https://i.scdn.co/image/449156e8f2458c247ea9a668e498c598b159f12f",
-    "width" : 640
-  } ],
-  "name" : "O.A.R. — The Rockville LP",
+  "href" : "https://api.spotify.com/v1/playlists/5lH9NjOeJvctAO92ZrKQNB?fields=href,name,owner(!href,external_urls),tracks.items(added_by.id,track(name,href,album(name,href)))",
+  "name" : "Top 40",
   "owner" : {
-    "external_urls" : {
-      "spotify" : "http://open.spotify.com/user/zbergquist99"
-    },
-    "href" : "https://api.spotify.com/v1/users/zbergquist99",
-    "id" : "zbergquist99",
+    "display_name" : "Nederlandse Top 40",
+    "id" : "nederlandse_top_40",
     "type" : "user",
-    "uri" : "spotify:user:zbergquist99"
+    "uri" : "spotify:user:nederlandse_top_40"
   },
-  "public" : true,
-  "snapshot_id" : "Yo+BthwRfySLE498r55BaKSJNw0/3ZDUzVYBcRxVtMReZ3joqyhIlBoMJKif2OWJ",
   "tracks" : {
-    "href" : "https://api.spotify.com/v1/users/zbergquist99/playlists/7I6yjOAxMq4qsvzgqxw7aU/tracks?offset=0&limit=100",
     "items" : [ {
-      "added_at" : "2014-06-10T11:23:19Z",
       "added_by" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/zbergquist99"
-        },
-        "href" : "https://api.spotify.com/v1/users/zbergquist99",
-        "id" : "zbergquist99",
-        "type" : "user",
-        "uri" : "spotify:user:zbergquist99"
+        "id" : "nederlandse_top_40"
       },
       "track" : {
         "album" : {
-          "album_type" : "album",
-          "available_markets" : [ "CA", "MX", "US" ],
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/album/23PusidYfyDzIC8X9l640f"
-          },
-          "href" : "https://api.spotify.com/v1/albums/23PusidYfyDzIC8X9l640f",
-          "id" : "23PusidYfyDzIC8X9l640f",
-          "images" : [ {
-            "height" : 640,
-            "url" : "https://i.scdn.co/image/449156e8f2458c247ea9a668e498c598b159f12f",
-            "width" : 640
-          }, {
-            "height" : 300,
-            "url" : "https://i.scdn.co/image/7d97f285065b275e5540cf88300f4ed3218c016e",
-            "width" : 300
-          }, {
-            "height" : 64,
-            "url" : "https://i.scdn.co/image/7267f52295e79b20481c72e3a52731953b6d209e",
-            "width" : 64
-          } ],
-          "name" : "The Rockville LP",
-          "type" : "album",
-          "uri" : "spotify:album:23PusidYfyDzIC8X9l640f"
+          "href" : "https://api.spotify.com/v1/albums/37iaWiKMa9YBbEDlw5c3Qh",
+          "name" : "Calm Down"
         },
-        "artists" : [ {
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/artist/1Cq0LAHFfvUTBEtMPXUidI"
-          },
-          "href" : "https://api.spotify.com/v1/artists/1Cq0LAHFfvUTBEtMPXUidI",
-          "id" : "1Cq0LAHFfvUTBEtMPXUidI",
-          "name" : "O.A.R.",
-          "type" : "artist",
-          "uri" : "spotify:artist:1Cq0LAHFfvUTBEtMPXUidI"
-        } ],
-        "available_markets" : [ "CA", "MX", "US" ],
-        "disc_number" : 1,
-        "duration_ms" : 189508,
-        "explicit" : false,
-        "external_ids" : {
-          "isrc" : "USVG21403537"
-        },
-        "external_urls" : {
-          "spotify" : "https://open.spotify.com/track/3eL2TpzK8nJyaAq7DRafh3"
-        },
-        "href" : "https://api.spotify.com/v1/tracks/3eL2TpzK8nJyaAq7DRafh3",
-        "id" : "3eL2TpzK8nJyaAq7DRafh3",
-        "name" : "Two Hands Up",
-        "popularity" : 46,
-        "preview_url" : "https://p.scdn.co/mp3-preview/a42b99a34899e9c99386c20a35cf8ef138be642d",
-        "track_number" : 1,
-        "type" : "track",
-        "uri" : "spotify:track:3eL2TpzK8nJyaAq7DRafh3"
+        "href" : "https://api.spotify.com/v1/tracks/6hgoYQDUcPyCz7LcTUHKxa",
+        "name" : "Calm Down"
       }
     }, {
-      "added_at" : "2014-06-10T11:23:19Z",
       "added_by" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/zbergquist99"
-        },
-        "href" : "https://api.spotify.com/v1/users/zbergquist99",
-        "id" : "zbergquist99",
-        "type" : "user",
-        "uri" : "spotify:user:zbergquist99"
+        "id" : "nederlandse_top_40"
       },
       "track" : {
         "album" : {
-          "album_type" : "album",
-          "available_markets" : [ "CA", "MX", "US" ],
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/album/23PusidYfyDzIC8X9l640f"
-          },
-          "href" : "https://api.spotify.com/v1/albums/23PusidYfyDzIC8X9l640f",
-          "id" : "23PusidYfyDzIC8X9l640f",
-          "images" : [ {
-            "height" : 640,
-            "url" : "https://i.scdn.co/image/449156e8f2458c247ea9a668e498c598b159f12f",
-            "width" : 640
-          }, {
-            "height" : 300,
-            "url" : "https://i.scdn.co/image/7d97f285065b275e5540cf88300f4ed3218c016e",
-            "width" : 300
-          }, {
-            "height" : 64,
-            "url" : "https://i.scdn.co/image/7267f52295e79b20481c72e3a52731953b6d209e",
-            "width" : 64
-          } ],
-          "name" : "The Rockville LP",
-          "type" : "album",
-          "uri" : "spotify:album:23PusidYfyDzIC8X9l640f"
+          "href" : "https://api.spotify.com/v1/albums/4Cv9qCS1q3FDyyRFHGyc1g",
+          "name" : "SNAP"
         },
-        "artists" : [ {
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/artist/1Cq0LAHFfvUTBEtMPXUidI"
-          },
-          "href" : "https://api.spotify.com/v1/artists/1Cq0LAHFfvUTBEtMPXUidI",
-          "id" : "1Cq0LAHFfvUTBEtMPXUidI",
-          "name" : "O.A.R.",
-          "type" : "artist",
-          "uri" : "spotify:artist:1Cq0LAHFfvUTBEtMPXUidI"
-        } ],
-        "available_markets" : [ "CA", "MX", "US" ],
-        "disc_number" : 1,
-        "duration_ms" : 206590,
-        "explicit" : false,
-        "external_ids" : {
-          "isrc" : "USVG21403538"
-        },
-        "external_urls" : {
-          "spotify" : "https://open.spotify.com/track/1l7E6PxXL78DscO7YEDSBc"
-        },
-        "href" : "https://api.spotify.com/v1/tracks/1l7E6PxXL78DscO7YEDSBc",
-        "id" : "1l7E6PxXL78DscO7YEDSBc",
-        "name" : "We'll Pick Up Where We Left Off",
-        "popularity" : 43,
-        "preview_url" : "https://p.scdn.co/mp3-preview/e107d8f17f036868d8389de406bae057bb609afa",
-        "track_number" : 2,
-        "type" : "track",
-        "uri" : "spotify:track:1l7E6PxXL78DscO7YEDSBc"
+        "href" : "https://api.spotify.com/v1/tracks/0QPRDC97rIQB3Jh3hrVJoH",
+        "name" : "SNAP"
       }
     }, {
-      "added_at" : "2014-06-10T11:23:19Z",
       "added_by" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/zbergquist99"
-        },
-        "href" : "https://api.spotify.com/v1/users/zbergquist99",
-        "id" : "zbergquist99",
-        "type" : "user",
-        "uri" : "spotify:user:zbergquist99"
+        "id" : "nederlandse_top_40"
       },
       "track" : {
         "album" : {
-          "album_type" : "album",
-          "available_markets" : [ "CA", "MX", "US" ],
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/album/23PusidYfyDzIC8X9l640f"
-          },
-          "href" : "https://api.spotify.com/v1/albums/23PusidYfyDzIC8X9l640f",
-          "id" : "23PusidYfyDzIC8X9l640f",
-          "images" : [ {
-            "height" : 640,
-            "url" : "https://i.scdn.co/image/449156e8f2458c247ea9a668e498c598b159f12f",
-            "width" : 640
-          }, {
-            "height" : 300,
-            "url" : "https://i.scdn.co/image/7d97f285065b275e5540cf88300f4ed3218c016e",
-            "width" : 300
-          }, {
-            "height" : 64,
-            "url" : "https://i.scdn.co/image/7267f52295e79b20481c72e3a52731953b6d209e",
-            "width" : 64
-          } ],
-          "name" : "The Rockville LP",
-          "type" : "album",
-          "uri" : "spotify:album:23PusidYfyDzIC8X9l640f"
+          "href" : "https://api.spotify.com/v1/albums/66W7mt0wKGLFALilLBLfU6",
+          "name" : "Words (feat. Zara Larsson)"
         },
-        "artists" : [ {
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/artist/1Cq0LAHFfvUTBEtMPXUidI"
-          },
-          "href" : "https://api.spotify.com/v1/artists/1Cq0LAHFfvUTBEtMPXUidI",
-          "id" : "1Cq0LAHFfvUTBEtMPXUidI",
-          "name" : "O.A.R.",
-          "type" : "artist",
-          "uri" : "spotify:artist:1Cq0LAHFfvUTBEtMPXUidI"
-        } ],
-        "available_markets" : [ "CA", "MX", "US" ],
-        "disc_number" : 1,
-        "duration_ms" : 215915,
-        "explicit" : false,
-        "external_ids" : {
-          "isrc" : "USVG21403507"
-        },
-        "external_urls" : {
-          "spotify" : "https://open.spotify.com/track/2xwsf9FuFINP1X4FTsqZ7Q"
-        },
-        "href" : "https://api.spotify.com/v1/tracks/2xwsf9FuFINP1X4FTsqZ7Q",
-        "id" : "2xwsf9FuFINP1X4FTsqZ7Q",
-        "name" : "Peace",
-        "popularity" : 63,
-        "preview_url" : "https://p.scdn.co/mp3-preview/284a912e61b3b609a856249db2d3c0294ad4ba6d",
-        "track_number" : 3,
-        "type" : "track",
-        "uri" : "spotify:track:2xwsf9FuFINP1X4FTsqZ7Q"
+        "href" : "https://api.spotify.com/v1/tracks/1bgKMxPQU7JIZEhNsM1vFs",
+        "name" : "Words (feat. Zara Larsson)"
       }
     }, {
-      "added_at" : "2014-06-10T11:23:19Z",
       "added_by" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/zbergquist99"
-        },
-        "href" : "https://api.spotify.com/v1/users/zbergquist99",
-        "id" : "zbergquist99",
-        "type" : "user",
-        "uri" : "spotify:user:zbergquist99"
+        "id" : "nederlandse_top_40"
       },
       "track" : {
         "album" : {
-          "album_type" : "album",
-          "available_markets" : [ "CA", "MX", "US" ],
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/album/23PusidYfyDzIC8X9l640f"
-          },
-          "href" : "https://api.spotify.com/v1/albums/23PusidYfyDzIC8X9l640f",
-          "id" : "23PusidYfyDzIC8X9l640f",
-          "images" : [ {
-            "height" : 640,
-            "url" : "https://i.scdn.co/image/449156e8f2458c247ea9a668e498c598b159f12f",
-            "width" : 640
-          }, {
-            "height" : 300,
-            "url" : "https://i.scdn.co/image/7d97f285065b275e5540cf88300f4ed3218c016e",
-            "width" : 300
-          }, {
-            "height" : 64,
-            "url" : "https://i.scdn.co/image/7267f52295e79b20481c72e3a52731953b6d209e",
-            "width" : 64
-          } ],
-          "name" : "The Rockville LP",
-          "type" : "album",
-          "uri" : "spotify:album:23PusidYfyDzIC8X9l640f"
+          "href" : "https://api.spotify.com/v1/albums/1Aq9FlSr9KanZFljnUnl2m",
+          "name" : "Multicolor"
         },
-        "artists" : [ {
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/artist/1Cq0LAHFfvUTBEtMPXUidI"
-          },
-          "href" : "https://api.spotify.com/v1/artists/1Cq0LAHFfvUTBEtMPXUidI",
-          "id" : "1Cq0LAHFfvUTBEtMPXUidI",
-          "name" : "O.A.R.",
-          "type" : "artist",
-          "uri" : "spotify:artist:1Cq0LAHFfvUTBEtMPXUidI"
-        } ],
-        "available_markets" : [ "CA", "MX", "US" ],
-        "disc_number" : 1,
-        "duration_ms" : 188402,
-        "explicit" : false,
-        "external_ids" : {
-          "isrc" : "USVG21403540"
-        },
-        "external_urls" : {
-          "spotify" : "https://open.spotify.com/track/4Xex8yWezu6gostXaeZ2qs"
-        },
-        "href" : "https://api.spotify.com/v1/tracks/4Xex8yWezu6gostXaeZ2qs",
-        "id" : "4Xex8yWezu6gostXaeZ2qs",
-        "name" : "The Element",
-        "popularity" : 42,
-        "preview_url" : "https://p.scdn.co/mp3-preview/c1c04603159d37ce88f27726c73f2640e0467001",
-        "track_number" : 4,
-        "type" : "track",
-        "uri" : "spotify:track:4Xex8yWezu6gostXaeZ2qs"
+        "href" : "https://api.spotify.com/v1/tracks/2ExdbieQffMXpY7ygN2YN9",
+        "name" : "Multicolor"
       }
     }, {
-      "added_at" : "2014-06-10T11:23:19Z",
       "added_by" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/zbergquist99"
-        },
-        "href" : "https://api.spotify.com/v1/users/zbergquist99",
-        "id" : "zbergquist99",
-        "type" : "user",
-        "uri" : "spotify:user:zbergquist99"
+        "id" : "nederlandse_top_40"
       },
       "track" : {
         "album" : {
-          "album_type" : "album",
-          "available_markets" : [ "CA", "MX", "US" ],
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/album/23PusidYfyDzIC8X9l640f"
-          },
-          "href" : "https://api.spotify.com/v1/albums/23PusidYfyDzIC8X9l640f",
-          "id" : "23PusidYfyDzIC8X9l640f",
-          "images" : [ {
-            "height" : 640,
-            "url" : "https://i.scdn.co/image/449156e8f2458c247ea9a668e498c598b159f12f",
-            "width" : 640
-          }, {
-            "height" : 300,
-            "url" : "https://i.scdn.co/image/7d97f285065b275e5540cf88300f4ed3218c016e",
-            "width" : 300
-          }, {
-            "height" : 64,
-            "url" : "https://i.scdn.co/image/7267f52295e79b20481c72e3a52731953b6d209e",
-            "width" : 64
-          } ],
-          "name" : "The Rockville LP",
-          "type" : "album",
-          "uri" : "spotify:album:23PusidYfyDzIC8X9l640f"
+          "href" : "https://api.spotify.com/v1/albums/7M842DMhYVALrXsw3ty7B3",
+          "name" : "I'm Good (Blue)"
         },
-        "artists" : [ {
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/artist/1Cq0LAHFfvUTBEtMPXUidI"
-          },
-          "href" : "https://api.spotify.com/v1/artists/1Cq0LAHFfvUTBEtMPXUidI",
-          "id" : "1Cq0LAHFfvUTBEtMPXUidI",
-          "name" : "O.A.R.",
-          "type" : "artist",
-          "uri" : "spotify:artist:1Cq0LAHFfvUTBEtMPXUidI"
-        } ],
-        "available_markets" : [ "CA", "MX", "US" ],
-        "disc_number" : 1,
-        "duration_ms" : 205038,
-        "explicit" : false,
-        "external_ids" : {
-          "isrc" : "USVG21403541"
-        },
-        "external_urls" : {
-          "spotify" : "https://open.spotify.com/track/3d2aDshX0T1IYXIqA4GguZ"
-        },
-        "href" : "https://api.spotify.com/v1/tracks/3d2aDshX0T1IYXIqA4GguZ",
-        "id" : "3d2aDshX0T1IYXIqA4GguZ",
-        "name" : "Favorite Song",
-        "popularity" : 48,
-        "preview_url" : "https://p.scdn.co/mp3-preview/62631744295d5b0b81200a114bec7e0e1bebbf66",
-        "track_number" : 5,
-        "type" : "track",
-        "uri" : "spotify:track:3d2aDshX0T1IYXIqA4GguZ"
+        "href" : "https://api.spotify.com/v1/tracks/4uUG5RXrOk84mYEfFvj3cK",
+        "name" : "I'm Good (Blue)"
       }
     }, {
-      "added_at" : "2014-06-10T11:23:19Z",
       "added_by" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/zbergquist99"
-        },
-        "href" : "https://api.spotify.com/v1/users/zbergquist99",
-        "id" : "zbergquist99",
-        "type" : "user",
-        "uri" : "spotify:user:zbergquist99"
+        "id" : "nederlandse_top_40"
       },
       "track" : {
         "album" : {
-          "album_type" : "album",
-          "available_markets" : [ "CA", "MX", "US" ],
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/album/23PusidYfyDzIC8X9l640f"
-          },
-          "href" : "https://api.spotify.com/v1/albums/23PusidYfyDzIC8X9l640f",
-          "id" : "23PusidYfyDzIC8X9l640f",
-          "images" : [ {
-            "height" : 640,
-            "url" : "https://i.scdn.co/image/449156e8f2458c247ea9a668e498c598b159f12f",
-            "width" : 640
-          }, {
-            "height" : 300,
-            "url" : "https://i.scdn.co/image/7d97f285065b275e5540cf88300f4ed3218c016e",
-            "width" : 300
-          }, {
-            "height" : 64,
-            "url" : "https://i.scdn.co/image/7267f52295e79b20481c72e3a52731953b6d209e",
-            "width" : 64
-          } ],
-          "name" : "The Rockville LP",
-          "type" : "album",
-          "uri" : "spotify:album:23PusidYfyDzIC8X9l640f"
+          "href" : "https://api.spotify.com/v1/albums/04PEOM6kIEeq9lRp1asNP2",
+          "name" : "I Ain’t Worried (Music From The Motion Picture \"Top Gun: Maverick\")"
         },
-        "artists" : [ {
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/artist/1Cq0LAHFfvUTBEtMPXUidI"
-          },
-          "href" : "https://api.spotify.com/v1/artists/1Cq0LAHFfvUTBEtMPXUidI",
-          "id" : "1Cq0LAHFfvUTBEtMPXUidI",
-          "name" : "O.A.R.",
-          "type" : "artist",
-          "uri" : "spotify:artist:1Cq0LAHFfvUTBEtMPXUidI"
-        } ],
-        "available_markets" : [ "CA", "MX", "US" ],
-        "disc_number" : 1,
-        "duration_ms" : 216687,
-        "explicit" : false,
-        "external_ids" : {
-          "isrc" : "USVG21403542"
-        },
-        "external_urls" : {
-          "spotify" : "https://open.spotify.com/track/69qE90aLw0iwMUbDDXZW5z"
-        },
-        "href" : "https://api.spotify.com/v1/tracks/69qE90aLw0iwMUbDDXZW5z",
-        "id" : "69qE90aLw0iwMUbDDXZW5z",
-        "name" : "So Good So Far",
-        "popularity" : 41,
-        "preview_url" : "https://p.scdn.co/mp3-preview/bd8a10d677b813e3410db3e38437e31e44f605ae",
-        "track_number" : 6,
-        "type" : "track",
-        "uri" : "spotify:track:69qE90aLw0iwMUbDDXZW5z"
+        "href" : "https://api.spotify.com/v1/tracks/4h9wh7iOZ0GGn8QVp4RAOB",
+        "name" : "I Ain't Worried"
       }
     }, {
-      "added_at" : "2014-06-10T11:23:19Z",
       "added_by" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/zbergquist99"
-        },
-        "href" : "https://api.spotify.com/v1/users/zbergquist99",
-        "id" : "zbergquist99",
-        "type" : "user",
-        "uri" : "spotify:user:zbergquist99"
+        "id" : "nederlandse_top_40"
       },
       "track" : {
         "album" : {
-          "album_type" : "album",
-          "available_markets" : [ "CA", "MX", "US" ],
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/album/23PusidYfyDzIC8X9l640f"
-          },
-          "href" : "https://api.spotify.com/v1/albums/23PusidYfyDzIC8X9l640f",
-          "id" : "23PusidYfyDzIC8X9l640f",
-          "images" : [ {
-            "height" : 640,
-            "url" : "https://i.scdn.co/image/449156e8f2458c247ea9a668e498c598b159f12f",
-            "width" : 640
-          }, {
-            "height" : 300,
-            "url" : "https://i.scdn.co/image/7d97f285065b275e5540cf88300f4ed3218c016e",
-            "width" : 300
-          }, {
-            "height" : 64,
-            "url" : "https://i.scdn.co/image/7267f52295e79b20481c72e3a52731953b6d209e",
-            "width" : 64
-          } ],
-          "name" : "The Rockville LP",
-          "type" : "album",
-          "uri" : "spotify:album:23PusidYfyDzIC8X9l640f"
+          "href" : "https://api.spotify.com/v1/albums/6dSmXsyGAnFtq048IFhiYd",
+          "name" : "In The Stars"
         },
-        "artists" : [ {
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/artist/1Cq0LAHFfvUTBEtMPXUidI"
-          },
-          "href" : "https://api.spotify.com/v1/artists/1Cq0LAHFfvUTBEtMPXUidI",
-          "id" : "1Cq0LAHFfvUTBEtMPXUidI",
-          "name" : "O.A.R.",
-          "type" : "artist",
-          "uri" : "spotify:artist:1Cq0LAHFfvUTBEtMPXUidI"
-        } ],
-        "available_markets" : [ "CA", "MX", "US" ],
-        "disc_number" : 1,
-        "duration_ms" : 250838,
-        "explicit" : false,
-        "external_ids" : {
-          "isrc" : "USVG21403543"
-        },
-        "external_urls" : {
-          "spotify" : "https://open.spotify.com/track/0GpCmz1dAGsTXpqJIp43XG"
-        },
-        "href" : "https://api.spotify.com/v1/tracks/0GpCmz1dAGsTXpqJIp43XG",
-        "id" : "0GpCmz1dAGsTXpqJIp43XG",
-        "name" : "The Architect",
-        "popularity" : 40,
-        "preview_url" : "https://p.scdn.co/mp3-preview/fb63b6cd5259d47ba31dc4b321bc33f602c82cf8",
-        "track_number" : 7,
-        "type" : "track",
-        "uri" : "spotify:track:0GpCmz1dAGsTXpqJIp43XG"
+        "href" : "https://api.spotify.com/v1/tracks/1ei3hzQmrgealgRKFxIcWn",
+        "name" : "In The Stars"
       }
     }, {
-      "added_at" : "2014-06-10T11:23:19Z",
       "added_by" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/zbergquist99"
-        },
-        "href" : "https://api.spotify.com/v1/users/zbergquist99",
-        "id" : "zbergquist99",
-        "type" : "user",
-        "uri" : "spotify:user:zbergquist99"
+        "id" : "nederlandse_top_40"
       },
       "track" : {
         "album" : {
-          "album_type" : "album",
-          "available_markets" : [ "CA", "MX", "US" ],
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/album/23PusidYfyDzIC8X9l640f"
-          },
-          "href" : "https://api.spotify.com/v1/albums/23PusidYfyDzIC8X9l640f",
-          "id" : "23PusidYfyDzIC8X9l640f",
-          "images" : [ {
-            "height" : 640,
-            "url" : "https://i.scdn.co/image/449156e8f2458c247ea9a668e498c598b159f12f",
-            "width" : 640
-          }, {
-            "height" : 300,
-            "url" : "https://i.scdn.co/image/7d97f285065b275e5540cf88300f4ed3218c016e",
-            "width" : 300
-          }, {
-            "height" : 64,
-            "url" : "https://i.scdn.co/image/7267f52295e79b20481c72e3a52731953b6d209e",
-            "width" : 64
-          } ],
-          "name" : "The Rockville LP",
-          "type" : "album",
-          "uri" : "spotify:album:23PusidYfyDzIC8X9l640f"
+          "href" : "https://api.spotify.com/v1/albums/5F9Y7Rx1ILWqQQXVilf0KN",
+          "name" : "Through The Looking Glass"
         },
-        "artists" : [ {
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/artist/1Cq0LAHFfvUTBEtMPXUidI"
-          },
-          "href" : "https://api.spotify.com/v1/artists/1Cq0LAHFfvUTBEtMPXUidI",
-          "id" : "1Cq0LAHFfvUTBEtMPXUidI",
-          "name" : "O.A.R.",
-          "type" : "artist",
-          "uri" : "spotify:artist:1Cq0LAHFfvUTBEtMPXUidI"
-        } ],
-        "available_markets" : [ "CA", "MX", "US" ],
-        "disc_number" : 1,
-        "duration_ms" : 289501,
-        "explicit" : false,
-        "external_ids" : {
-          "isrc" : "USVG21403544"
-        },
-        "external_urls" : {
-          "spotify" : "https://open.spotify.com/track/5iXpnUwj4fI5qObReUg32W"
-        },
-        "href" : "https://api.spotify.com/v1/tracks/5iXpnUwj4fI5qObReUg32W",
-        "id" : "5iXpnUwj4fI5qObReUg32W",
-        "name" : "Place To Hide",
-        "popularity" : 41,
-        "preview_url" : "https://p.scdn.co/mp3-preview/391bed0461962a3479233c5c066d5b3d0fc9dd53",
-        "track_number" : 8,
-        "type" : "track",
-        "uri" : "spotify:track:5iXpnUwj4fI5qObReUg32W"
+        "href" : "https://api.spotify.com/v1/tracks/7j2TJXhcE1aAzB6Evmgvm0",
+        "name" : "Through The Looking Glass"
       }
     }, {
-      "added_at" : "2014-06-10T11:23:19Z",
       "added_by" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/zbergquist99"
-        },
-        "href" : "https://api.spotify.com/v1/users/zbergquist99",
-        "id" : "zbergquist99",
-        "type" : "user",
-        "uri" : "spotify:user:zbergquist99"
+        "id" : "nederlandse_top_40"
       },
       "track" : {
         "album" : {
-          "album_type" : "album",
-          "available_markets" : [ "CA", "MX", "US" ],
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/album/23PusidYfyDzIC8X9l640f"
-          },
-          "href" : "https://api.spotify.com/v1/albums/23PusidYfyDzIC8X9l640f",
-          "id" : "23PusidYfyDzIC8X9l640f",
-          "images" : [ {
-            "height" : 640,
-            "url" : "https://i.scdn.co/image/449156e8f2458c247ea9a668e498c598b159f12f",
-            "width" : 640
-          }, {
-            "height" : 300,
-            "url" : "https://i.scdn.co/image/7d97f285065b275e5540cf88300f4ed3218c016e",
-            "width" : 300
-          }, {
-            "height" : 64,
-            "url" : "https://i.scdn.co/image/7267f52295e79b20481c72e3a52731953b6d209e",
-            "width" : 64
-          } ],
-          "name" : "The Rockville LP",
-          "type" : "album",
-          "uri" : "spotify:album:23PusidYfyDzIC8X9l640f"
+          "href" : "https://api.spotify.com/v1/albums/2e0yXV8bjdl4cqWwp1KG8T",
+          "name" : "I Want You"
         },
-        "artists" : [ {
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/artist/1Cq0LAHFfvUTBEtMPXUidI"
-          },
-          "href" : "https://api.spotify.com/v1/artists/1Cq0LAHFfvUTBEtMPXUidI",
-          "id" : "1Cq0LAHFfvUTBEtMPXUidI",
-          "name" : "O.A.R.",
-          "type" : "artist",
-          "uri" : "spotify:artist:1Cq0LAHFfvUTBEtMPXUidI"
-        } ],
-        "available_markets" : [ "CA", "MX", "US" ],
-        "disc_number" : 1,
-        "duration_ms" : 412716,
-        "explicit" : false,
-        "external_ids" : {
-          "isrc" : "USVG21403545"
-        },
-        "external_urls" : {
-          "spotify" : "https://open.spotify.com/track/6dvjzJqpFKUr0dkdvKNvbc"
-        },
-        "href" : "https://api.spotify.com/v1/tracks/6dvjzJqpFKUr0dkdvKNvbc",
-        "id" : "6dvjzJqpFKUr0dkdvKNvbc",
-        "name" : "Caroline The Wrecking Ball",
-        "popularity" : 39,
-        "preview_url" : "https://p.scdn.co/mp3-preview/b2fa29845883d5ddcc008d305030b354a370eb53",
-        "track_number" : 9,
-        "type" : "track",
-        "uri" : "spotify:track:6dvjzJqpFKUr0dkdvKNvbc"
+        "href" : "https://api.spotify.com/v1/tracks/4s8BpmFtxDgeCoPj2XHtVj",
+        "name" : "I Want You"
       }
     }, {
-      "added_at" : "2014-06-10T11:23:19Z",
       "added_by" : {
-        "external_urls" : {
-          "spotify" : "http://open.spotify.com/user/zbergquist99"
-        },
-        "href" : "https://api.spotify.com/v1/users/zbergquist99",
-        "id" : "zbergquist99",
-        "type" : "user",
-        "uri" : "spotify:user:zbergquist99"
+        "id" : "nederlandse_top_40"
       },
       "track" : {
         "album" : {
-          "album_type" : "album",
-          "available_markets" : [ "CA", "MX", "US" ],
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/album/23PusidYfyDzIC8X9l640f"
-          },
-          "href" : "https://api.spotify.com/v1/albums/23PusidYfyDzIC8X9l640f",
-          "id" : "23PusidYfyDzIC8X9l640f",
-          "images" : [ {
-            "height" : 640,
-            "url" : "https://i.scdn.co/image/449156e8f2458c247ea9a668e498c598b159f12f",
-            "width" : 640
-          }, {
-            "height" : 300,
-            "url" : "https://i.scdn.co/image/7d97f285065b275e5540cf88300f4ed3218c016e",
-            "width" : 300
-          }, {
-            "height" : 64,
-            "url" : "https://i.scdn.co/image/7267f52295e79b20481c72e3a52731953b6d209e",
-            "width" : 64
-          } ],
-          "name" : "The Rockville LP",
-          "type" : "album",
-          "uri" : "spotify:album:23PusidYfyDzIC8X9l640f"
+          "href" : "https://api.spotify.com/v1/albums/2pqdSWeJVsXAhHFuVLzuA8",
+          "name" : "As It Was"
         },
-        "artists" : [ {
-          "external_urls" : {
-            "spotify" : "https://open.spotify.com/artist/1Cq0LAHFfvUTBEtMPXUidI"
-          },
-          "href" : "https://api.spotify.com/v1/artists/1Cq0LAHFfvUTBEtMPXUidI",
-          "id" : "1Cq0LAHFfvUTBEtMPXUidI",
-          "name" : "O.A.R.",
-          "type" : "artist",
-          "uri" : "spotify:artist:1Cq0LAHFfvUTBEtMPXUidI"
-        } ],
-        "available_markets" : [ "CA", "MX", "US" ],
-        "disc_number" : 1,
-        "duration_ms" : 541787,
-        "explicit" : false,
-        "external_ids" : {
-          "isrc" : "USVG21403546"
-        },
-        "external_urls" : {
-          "spotify" : "https://open.spotify.com/track/43ByDewjtOwEZXi9qI2J66"
-        },
-        "href" : "https://api.spotify.com/v1/tracks/43ByDewjtOwEZXi9qI2J66",
-        "id" : "43ByDewjtOwEZXi9qI2J66",
-        "name" : "I Will Find You",
-        "popularity" : 39,
-        "preview_url" : "https://p.scdn.co/mp3-preview/894236ed584f6e9c72352c57325f820d41247307",
-        "track_number" : 10,
-        "type" : "track",
-        "uri" : "spotify:track:43ByDewjtOwEZXi9qI2J66"
+        "href" : "https://api.spotify.com/v1/tracks/4LRPiXqCikLlN15c3yImP7",
+        "name" : "As It Was"
       }
-    } ],
-    "limit" : 100,
-    "next" : null,
-    "offset" : 0,
-    "previous" : null,
-    "total" : 10
-  },
-  "type" : "playlist",
-  "uri" : "spotify:user:zbergquist99:playlist:7I6yjOAxMq4qsvzgqxw7aU"
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/44aG7QLYLGotCTlu5Fc2J7",
+          "name" : "Bad Memories (feat. Elley Duhé & FAST BOY)"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/3rb0tMq42WfggucPm0HHkA",
+        "name" : "Bad Memories (feat. Elley Duhé & FAST BOY)"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/528LrHfHcB7PMAvyp8Obhp",
+          "name" : "Afraid To Feel"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/40SBS57su9xLiE1WqkXOVr",
+        "name" : "Afraid To Feel"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/7CX6KwcrRx0iwTH8iU6rDJ",
+          "name" : "Solo Para Ti"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/2uAgZ0PelSImQe3BME9CiT",
+        "name" : "Solo Para Ti"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/1ORFwaAJM7agyaN1ZLiUHs",
+          "name" : "Automatisch"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/2WeAyT93f7IzrwXm3ZJMb2",
+        "name" : "Automatisch"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/3KpxpdySrMR2S7noneu1bI",
+          "name" : "Deep Down (feat. Never Dull)"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/7MIhUdNJtaOnDmC5nBC1fb",
+        "name" : "Deep Down (feat. Never Dull)"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/1p6j020MWD6BCELPZd8XVC",
+          "name" : "Green Green Grass"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/3rk4aJ0vAj3cFUIQEeASkT",
+        "name" : "Green Green Grass"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/6R7Yy0sY9N8PNUhseegr2Q",
+          "name" : "Hot In It"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/3Z7CaxQkqbIs1rewKi6v4W",
+        "name" : "Hot In It"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/4umTGjL6WgGnfoJWgz1uHe",
+          "name" : "Van Mij Zijn"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/3oFKhY9iW9S0iA9OHO9tN6",
+        "name" : "Van Mij Zijn"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/312M1zzN7C2Vqd0VeORTMC",
+          "name" : "Come Around Again"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/55Y4oE6oE6XBT2e71vK2yA",
+        "name" : "Come Around Again"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/7xgmfo0gHFJk9DNdOfqBNn",
+          "name" : "We Could Be Together (feat. Daddy DJ)"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/3ElGRG3DqSzzkh1b2wnbzf",
+        "name" : "We Could Be Together (feat. Daddy DJ)"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/5r36AJ6VOJtp00oxSkBZ5h",
+          "name" : "Harry's House"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/1qEmFfgcLObUfQm0j1W2CK",
+        "name" : "Late Night Talking"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/4QQWpCEX4BxMXwRQmtkKY6",
+          "name" : "Hold Me Closer"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/72yP0DUlWPyH8P7IoxskwN",
+        "name" : "Hold Me Closer"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/4WLkmuc0lGCBJLtj1yxJI0",
+          "name" : "Ferrari"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/5xKJI9aPQhuTdTq8BrJ8fL",
+        "name" : "Ferrari"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/0rgJvUPcgTDdiirvy7wHs6",
+          "name" : "Electric Life"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/0iLqpm5c4dGlwth5LYq2tj",
+        "name" : "Electric Life"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/6eEQ0sXVp92CmSL5SsfvY3",
+          "name" : "Trompeta"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/5cppeoXfiK59UEsEeOvuNo",
+        "name" : "Trompeta"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/5HyQdrY2jAKPhK1OqX7yOR",
+          "name" : "Questions"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/1cgy2FSOQMbq7DHCVgMAUA",
+        "name" : "Questions"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/118PKNjhP4NWcrW5OjMwzc",
+          "name" : "21 Reasons (feat. Ella Henderson)"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/1RF02Cf80mTaeNXG2P2boR",
+        "name" : "21 Reasons (feat. Ella Henderson)"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/3HdzIBLsdVX4RTuA4zxumb",
+          "name" : "Kwijt"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/1dbNg2ougivyUv6f9hQQzU",
+        "name" : "Kwijt"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/1R7H7T15beGxVaQQ1MnH78",
+          "name" : "HISTORY"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/5IfHQilcjciOxJQBFCNCCN",
+        "name" : "HISTORY"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/3plMoBhvQ07H4itII2Qdeb",
+          "name" : "DON'T YOU WORRY"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/0gYXw7aPoybWFfB7btQ0eM",
+        "name" : "DON'T YOU WORRY"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/2wht4rGcaS39dbSxrvdfEL",
+          "name" : "Darte Un Beso"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/3ZGJTUAhwua3fBi2M9BOUQ",
+        "name" : "Darte Un Beso"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/1mAlhigBTplhT8aYBo9tFc",
+          "name" : "Terug Bij Af ft. Ronnie Flex"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/65rDc2X5XZNs9mCvnJyaR1",
+        "name" : "Terug Bij Af ft. Ronnie Flex"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/62SWIKrov7HPXU0Jpc6LY1",
+          "name" : "Stay With Me (with Justin Timberlake, Halsey, & Pharrell)"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/5lfWrciYtohtIMVDVZd0Rf",
+        "name" : "Stay With Me (with Justin Timberlake, Halsey, & Pharrell)"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/55hLMMakne8TwUe39HmDZ1",
+          "name" : "Noodgeval"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/27NXXRJAv6Oa8WdtAbhrTR",
+        "name" : "Noodgeval"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/4Aki0Qb1ior78C1RcWb5oX",
+          "name" : "Camino"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/50UWMLI07e82G1VLMZ2M11",
+        "name" : "Camino"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/0VaHnwzDug4AcDkejYDUl5",
+          "name" : "Sunroof"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/4h4QlmocP3IuwYEj2j14p8",
+        "name" : "Sunroof"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/587Ykd8NOCdzRmaW4nlT4e",
+          "name" : "Sharks"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/0TyUOnU4H4GLqOcrH0auc8",
+        "name" : "Sharks"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/2NIChqkijGw4r4Dqfmg0A3",
+          "name" : "Kernkraft 400 (A Better Day)"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/3kcKlOkQQEPVwxwljbGJ5p",
+        "name" : "Kernkraft 400 (A Better Day)"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/06mXfvDsRZNfnsGZvX2zpb",
+          "name" : "Music Of The Spheres"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/23BO6YozrAXUta1buxFZ80",
+        "name" : "Humankind"
+      }
+    }, {
+      "added_by" : {
+        "id" : "nederlandse_top_40"
+      },
+      "track" : {
+        "album" : {
+          "href" : "https://api.spotify.com/v1/albums/3R69AWht6e2vZq7Cg3XGPH",
+          "name" : "The Drop"
+        },
+        "href" : "https://api.spotify.com/v1/tracks/013PVeWEFQio3XHFH9rIC6",
+        "name" : "The Drop"
+      }
+    } ]
+  }
 }

--- a/test_data/playlist_tracks.txt
+++ b/test_data/playlist_tracks.txt
@@ -1,150 +1,3993 @@
 {
-  "href" : "https://api.spotify.com/v1/users/spotify_espa%C3%B1a/playlists/21THa8j9TaSGuXYNBU5tsC/tracks?offset=0&limit=2",
+  "href" : "https://api.spotify.com/v1/playlists/5lH9NjOeJvctAO92ZrKQNB/tracks?offset=0&limit=100",
   "items" : [ {
-    "added_at" : "2014-11-25T18:15:01Z",
+    "added_at" : "2022-07-15T19:37:22Z",
     "added_by" : {
       "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/spotify_espa%C3%B1a"
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
       },
-      "href" : "https://api.spotify.com/v1/users/spotify_espa%C3%B1a",
-      "id" : "spotify_españa",
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
       "type" : "user",
-      "uri" : "spotify:user:spotify_espa%C3%B1a"
+      "uri" : "spotify:user:nederlandse_top_40"
     },
-    "track" : {
-      "album" : {
-        "album_type" : "album",
-        "available_markets" : [ "AD", "AR", "AT", "AU", "BE", "BG", "BO", "BR", "CA", "CH", "CL", "CO", "CR", "CY", "CZ", "DE", "DK", "DO", "EC", "EE", "ES", "FI", "FR", "GB", "GR", "GT", "HK", "HN", "HU", "IE", "IS", "IT", "LI", "LT", "LU", "LV", "MC", "MT", "MX", "MY", "NI", "NL", "NO", "NZ", "PA", "PE", "PH", "PL", "PT", "PY", "RO", "SE", "SG", "SI", "SK", "SV", "TR", "TW", "US", "UY" ],
-        "external_urls" : {
-          "spotify" : "https://open.spotify.com/album/4EUf4YyNjuXypWY6W5wEDm"
-        },
-        "href" : "https://api.spotify.com/v1/albums/4EUf4YyNjuXypWY6W5wEDm",
-        "id" : "4EUf4YyNjuXypWY6W5wEDm",
-        "images" : [ {
-          "height" : 640,
-          "url" : "https://i.scdn.co/image/835884befb1b595476e590e656f27b3ec028308b",
-          "width" : 640
-        }, {
-          "height" : 300,
-          "url" : "https://i.scdn.co/image/b3074557f3c45bb3a2c9884ecbfeb692f3c51be4",
-          "width" : 300
-        }, {
-          "height" : 64,
-          "url" : "https://i.scdn.co/image/6dc754ec4bc27563dc707fb2178a55c71b7352c9",
-          "width" : 64
-        } ],
-        "name" : "Globalization",
-        "type" : "album",
-        "uri" : "spotify:album:4EUf4YyNjuXypWY6W5wEDm"
-      },
-      "artists" : [ {
-        "external_urls" : {
-          "spotify" : "https://open.spotify.com/artist/0TnOYISbd1XYRBk9myaseg"
-        },
-        "href" : "https://api.spotify.com/v1/artists/0TnOYISbd1XYRBk9myaseg",
-        "id" : "0TnOYISbd1XYRBk9myaseg",
-        "name" : "Pitbull",
-        "type" : "artist",
-        "uri" : "spotify:artist:0TnOYISbd1XYRBk9myaseg"
-      }, {
-        "external_urls" : {
-          "spotify" : "https://open.spotify.com/artist/21E3waRsmPlU7jZsS13rcj"
-        },
-        "href" : "https://api.spotify.com/v1/artists/21E3waRsmPlU7jZsS13rcj",
-        "id" : "21E3waRsmPlU7jZsS13rcj",
-        "name" : "Ne-Yo",
-        "type" : "artist",
-        "uri" : "spotify:artist:21E3waRsmPlU7jZsS13rcj"
-      } ],
-      "available_markets" : [ "AD", "AR", "AT", "AU", "BE", "BG", "BO", "BR", "CA", "CH", "CL", "CO", "CR", "CY", "CZ", "DE", "DK", "DO", "EC", "EE", "ES", "FI", "FR", "GB", "GR", "GT", "HK", "HN", "HU", "IE", "IS", "IT", "LI", "LT", "LU", "LV", "MC", "MT", "MX", "MY", "NI", "NL", "NO", "NZ", "PA", "PE", "PH", "PL", "PT", "PY", "RO", "SE", "SG", "SI", "SK", "SV", "TR", "TW", "US", "UY" ],
-      "disc_number" : 1,
-      "duration_ms" : 229360,
-      "explicit" : true,
-      "external_ids" : {
-        "isrc" : "USRC11402647"
-      },
-      "external_urls" : {
-        "spotify" : "https://open.spotify.com/track/2bJvI42r8EF3wxjOuDav4r"
-      },
-      "href" : "https://api.spotify.com/v1/tracks/2bJvI42r8EF3wxjOuDav4r",
-      "id" : "2bJvI42r8EF3wxjOuDav4r",
-      "name" : "Time Of Our Lives",
-      "popularity" : 88,
-      "preview_url" : "https://p.scdn.co/mp3-preview/f6cd2dac5beb16dc277d92ba4656df19765f9ab6",
-      "track_number" : 4,
-      "type" : "track",
-      "uri" : "spotify:track:2bJvI42r8EF3wxjOuDav4r"
-    }
-  }, {
-    "added_at" : "2014-12-17T22:17:49Z",
-    "added_by" : {
-      "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/spotify_espa%C3%B1a"
-      },
-      "href" : "https://api.spotify.com/v1/users/spotify_espa%C3%B1a",
-      "id" : "spotify_españa",
-      "type" : "user",
-      "uri" : "spotify:user:spotify_espa%C3%B1a"
-    },
+    "is_local" : false,
+    "primary_color" : null,
     "track" : {
       "album" : {
         "album_type" : "single",
-        "available_markets" : [ "AD", "AR", "AT", "AU", "BE", "BG", "BO", "BR", "CA", "CH", "CL", "CO", "CR", "CY", "CZ", "DE", "DK", "DO", "EC", "EE", "ES", "FI", "FR", "GB", "GR", "GT", "HK", "HN", "HU", "IE", "IS", "IT", "LI", "LT", "LU", "LV", "MC", "MT", "MX", "MY", "NI", "NL", "NO", "NZ", "PA", "PE", "PH", "PL", "PT", "PY", "RO", "SE", "SG", "SI", "SK", "SV", "TR", "TW", "US", "UY" ],
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/46pWGuE3dSwY3bMMXGBvVS"
+          },
+          "href" : "https://api.spotify.com/v1/artists/46pWGuE3dSwY3bMMXGBvVS",
+          "id" : "46pWGuE3dSwY3bMMXGBvVS",
+          "name" : "Rema",
+          "type" : "artist",
+          "uri" : "spotify:artist:46pWGuE3dSwY3bMMXGBvVS"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BG", "BH", "BN", "BO", "BR", "BS", "BT", "BY", "BZ", "CA", "CH", "CL", "CO", "CR", "CW", "CY", "CZ", "DE", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GB", "GD", "GE", "GR", "GT", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KG", "KH", "KI", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MH", "MK", "MN", "MO", "MT", "MV", "MX", "MY", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "SA", "SB", "SE", "SG", "SI", "SK", "SM", "SR", "SV", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "UA", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK" ],
         "external_urls" : {
-          "spotify" : "https://open.spotify.com/album/3XozpQpm9a1WIf4Ozv7558"
+          "spotify" : "https://open.spotify.com/album/37iaWiKMa9YBbEDlw5c3Qh"
         },
-        "href" : "https://api.spotify.com/v1/albums/3XozpQpm9a1WIf4Ozv7558",
-        "id" : "3XozpQpm9a1WIf4Ozv7558",
+        "href" : "https://api.spotify.com/v1/albums/37iaWiKMa9YBbEDlw5c3Qh",
+        "id" : "37iaWiKMa9YBbEDlw5c3Qh",
         "images" : [ {
           "height" : 640,
-          "url" : "https://i.scdn.co/image/da604d365fe1620a311b8310d274063fb629dfd3",
+          "url" : "https://i.scdn.co/image/ab67616d0000b2734104f6b4175d04d69ab73c85",
           "width" : 640
         }, {
           "height" : 300,
-          "url" : "https://i.scdn.co/image/1e3c47aaf37ddb8a6310e3cef14ff93dc5bc0889",
+          "url" : "https://i.scdn.co/image/ab67616d00001e024104f6b4175d04d69ab73c85",
           "width" : 300
         }, {
           "height" : 64,
-          "url" : "https://i.scdn.co/image/931682e759ecfb5a04faca6eddae7f9beb44b584",
+          "url" : "https://i.scdn.co/image/ab67616d000048514104f6b4175d04d69ab73c85",
           "width" : 64
         } ],
-        "name" : "Como Yo Le Doy",
+        "name" : "Calm Down",
+        "release_date" : "2022-02-10",
+        "release_date_precision" : "day",
+        "total_tracks" : 2,
         "type" : "album",
-        "uri" : "spotify:album:3XozpQpm9a1WIf4Ozv7558"
+        "uri" : "spotify:album:37iaWiKMa9YBbEDlw5c3Qh"
       },
       "artists" : [ {
         "external_urls" : {
-          "spotify" : "https://open.spotify.com/artist/1noWnd8QFQD9VLxWEeo4Zf"
+          "spotify" : "https://open.spotify.com/artist/46pWGuE3dSwY3bMMXGBvVS"
         },
-        "href" : "https://api.spotify.com/v1/artists/1noWnd8QFQD9VLxWEeo4Zf",
-        "id" : "1noWnd8QFQD9VLxWEeo4Zf",
-        "name" : "Don Miguelo",
+        "href" : "https://api.spotify.com/v1/artists/46pWGuE3dSwY3bMMXGBvVS",
+        "id" : "46pWGuE3dSwY3bMMXGBvVS",
+        "name" : "Rema",
         "type" : "artist",
-        "uri" : "spotify:artist:1noWnd8QFQD9VLxWEeo4Zf"
+        "uri" : "spotify:artist:46pWGuE3dSwY3bMMXGBvVS"
       } ],
-      "available_markets" : [ "AD", "AR", "AT", "AU", "BE", "BG", "BO", "BR", "CA", "CH", "CL", "CO", "CR", "CY", "CZ", "DE", "DK", "DO", "EC", "EE", "ES", "FI", "FR", "GB", "GR", "GT", "HK", "HN", "HU", "IE", "IS", "IT", "LI", "LT", "LU", "LV", "MC", "MT", "MX", "MY", "NI", "NL", "NO", "NZ", "PA", "PE", "PH", "PL", "PT", "PY", "RO", "SE", "SG", "SI", "SK", "SV", "TR", "TW", "US", "UY" ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BG", "BH", "BN", "BO", "BR", "BS", "BT", "BY", "BZ", "CA", "CH", "CL", "CO", "CR", "CW", "CY", "CZ", "DE", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GB", "GD", "GE", "GR", "GT", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KG", "KH", "KI", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MH", "MK", "MN", "MO", "MT", "MV", "MX", "MY", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "SA", "SB", "SE", "SG", "SI", "SK", "SM", "SR", "SV", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "UA", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK" ],
       "disc_number" : 1,
-      "duration_ms" : 222853,
+      "duration_ms" : 219813,
+      "episode" : false,
       "explicit" : false,
       "external_ids" : {
-        "isrc" : "uscgj1400749"
+        "isrc" : "NGA3B2214004"
       },
       "external_urls" : {
-        "spotify" : "https://open.spotify.com/track/07IZD41kFwKZbEkd1frD2M"
+        "spotify" : "https://open.spotify.com/track/6hgoYQDUcPyCz7LcTUHKxa"
       },
-      "href" : "https://api.spotify.com/v1/tracks/07IZD41kFwKZbEkd1frD2M",
-      "id" : "07IZD41kFwKZbEkd1frD2M",
-      "name" : "Como Yo Le Doy",
-      "popularity" : 67,
-      "preview_url" : "https://p.scdn.co/mp3-preview/37fafc0b532d01c1b33067a73b66b1c9f286b3eb",
+      "href" : "https://api.spotify.com/v1/tracks/6hgoYQDUcPyCz7LcTUHKxa",
+      "id" : "6hgoYQDUcPyCz7LcTUHKxa",
+      "is_local" : false,
+      "name" : "Calm Down",
+      "popularity" : 84,
+      "preview_url" : "https://p.scdn.co/mp3-preview/14c5b6f9604f950a2857e205a9afb7ea4e065f94?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
       "track_number" : 1,
       "type" : "track",
-      "uri" : "spotify:track:07IZD41kFwKZbEkd1frD2M"
+      "uri" : "spotify:track:6hgoYQDUcPyCz7LcTUHKxa"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-07-15T19:37:36Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/46xBNx0j6cwY6sD9LgMTm1"
+          },
+          "href" : "https://api.spotify.com/v1/artists/46xBNx0j6cwY6sD9LgMTm1",
+          "id" : "46xBNx0j6cwY6sD9LgMTm1",
+          "name" : "Rosa Linn",
+          "type" : "artist",
+          "uri" : "spotify:artist:46xBNx0j6cwY6sD9LgMTm1"
+        } ],
+        "available_markets" : [ ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/4Cv9qCS1q3FDyyRFHGyc1g"
+        },
+        "href" : "https://api.spotify.com/v1/albums/4Cv9qCS1q3FDyyRFHGyc1g",
+        "id" : "4Cv9qCS1q3FDyyRFHGyc1g",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273a00491b5790cba0fb6534594",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02a00491b5790cba0fb6534594",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851a00491b5790cba0fb6534594",
+          "width" : 64
+        } ],
+        "name" : "SNAP",
+        "release_date" : "2022-03-19",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:4Cv9qCS1q3FDyyRFHGyc1g"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/46xBNx0j6cwY6sD9LgMTm1"
+        },
+        "href" : "https://api.spotify.com/v1/artists/46xBNx0j6cwY6sD9LgMTm1",
+        "id" : "46xBNx0j6cwY6sD9LgMTm1",
+        "name" : "Rosa Linn",
+        "type" : "artist",
+        "uri" : "spotify:artist:46xBNx0j6cwY6sD9LgMTm1"
+      } ],
+      "available_markets" : [ ],
+      "disc_number" : 1,
+      "duration_ms" : 179551,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "QM4TX2221661"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/0QPRDC97rIQB3Jh3hrVJoH"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/0QPRDC97rIQB3Jh3hrVJoH",
+      "id" : "0QPRDC97rIQB3Jh3hrVJoH",
+      "is_local" : false,
+      "name" : "SNAP",
+      "popularity" : 80,
+      "preview_url" : null,
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:0QPRDC97rIQB3Jh3hrVJoH"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-06-17T15:37:18Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/4AVFqumd2ogHFlRbKIjp1t"
+          },
+          "href" : "https://api.spotify.com/v1/artists/4AVFqumd2ogHFlRbKIjp1t",
+          "id" : "4AVFqumd2ogHFlRbKIjp1t",
+          "name" : "Alesso",
+          "type" : "artist",
+          "uri" : "spotify:artist:4AVFqumd2ogHFlRbKIjp1t"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/1Xylc3o4UrD53lo9CvFvVg"
+          },
+          "href" : "https://api.spotify.com/v1/artists/1Xylc3o4UrD53lo9CvFvVg",
+          "id" : "1Xylc3o4UrD53lo9CvFvVg",
+          "name" : "Zara Larsson",
+          "type" : "artist",
+          "uri" : "spotify:artist:1Xylc3o4UrD53lo9CvFvVg"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/66W7mt0wKGLFALilLBLfU6"
+        },
+        "href" : "https://api.spotify.com/v1/albums/66W7mt0wKGLFALilLBLfU6",
+        "id" : "66W7mt0wKGLFALilLBLfU6",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b2738f9c368d8d0f5792ffc5d38e",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e028f9c368d8d0f5792ffc5d38e",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d000048518f9c368d8d0f5792ffc5d38e",
+          "width" : 64
+        } ],
+        "name" : "Words (feat. Zara Larsson)",
+        "release_date" : "2022-04-22",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:66W7mt0wKGLFALilLBLfU6"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/4AVFqumd2ogHFlRbKIjp1t"
+        },
+        "href" : "https://api.spotify.com/v1/artists/4AVFqumd2ogHFlRbKIjp1t",
+        "id" : "4AVFqumd2ogHFlRbKIjp1t",
+        "name" : "Alesso",
+        "type" : "artist",
+        "uri" : "spotify:artist:4AVFqumd2ogHFlRbKIjp1t"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/1Xylc3o4UrD53lo9CvFvVg"
+        },
+        "href" : "https://api.spotify.com/v1/artists/1Xylc3o4UrD53lo9CvFvVg",
+        "id" : "1Xylc3o4UrD53lo9CvFvVg",
+        "name" : "Zara Larsson",
+        "type" : "artist",
+        "uri" : "spotify:artist:1Xylc3o4UrD53lo9CvFvVg"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 142677,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "USUG12202336"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/1bgKMxPQU7JIZEhNsM1vFs"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/1bgKMxPQU7JIZEhNsM1vFs",
+      "id" : "1bgKMxPQU7JIZEhNsM1vFs",
+      "is_local" : false,
+      "name" : "Words (feat. Zara Larsson)",
+      "popularity" : 85,
+      "preview_url" : "https://p.scdn.co/mp3-preview/eaab8e934fa280d38e832169a1da0fb309e8da55?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:1bgKMxPQU7JIZEhNsM1vFs"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-06-24T12:45:18Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/1BCBAzjX8J0qpvNTPRDCLc"
+          },
+          "href" : "https://api.spotify.com/v1/artists/1BCBAzjX8J0qpvNTPRDCLc",
+          "id" : "1BCBAzjX8J0qpvNTPRDCLc",
+          "name" : "Son Mieux",
+          "type" : "artist",
+          "uri" : "spotify:artist:1BCBAzjX8J0qpvNTPRDCLc"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/1Aq9FlSr9KanZFljnUnl2m"
+        },
+        "href" : "https://api.spotify.com/v1/albums/1Aq9FlSr9KanZFljnUnl2m",
+        "id" : "1Aq9FlSr9KanZFljnUnl2m",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b2732f153316c9dcce738cb8510f",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e022f153316c9dcce738cb8510f",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d000048512f153316c9dcce738cb8510f",
+          "width" : 64
+        } ],
+        "name" : "Multicolor",
+        "release_date" : "2022-04-15",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:1Aq9FlSr9KanZFljnUnl2m"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/1BCBAzjX8J0qpvNTPRDCLc"
+        },
+        "href" : "https://api.spotify.com/v1/artists/1BCBAzjX8J0qpvNTPRDCLc",
+        "id" : "1BCBAzjX8J0qpvNTPRDCLc",
+        "name" : "Son Mieux",
+        "type" : "artist",
+        "uri" : "spotify:artist:1BCBAzjX8J0qpvNTPRDCLc"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 208680,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "NLV3A2200001"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/2ExdbieQffMXpY7ygN2YN9"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/2ExdbieQffMXpY7ygN2YN9",
+      "id" : "2ExdbieQffMXpY7ygN2YN9",
+      "is_local" : false,
+      "name" : "Multicolor",
+      "popularity" : 70,
+      "preview_url" : "https://p.scdn.co/mp3-preview/85b3e936c4585c4193a3ec4e2058e26f4e80315b?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:2ExdbieQffMXpY7ygN2YN9"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-09-02T17:11:28Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          "href" : "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+          "id" : "1Cs0zKBU1kc0i8ypK3B9ai",
+          "name" : "David Guetta",
+          "type" : "artist",
+          "uri" : "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/64M6ah0SkkRsnPGtGiRAbb"
+          },
+          "href" : "https://api.spotify.com/v1/artists/64M6ah0SkkRsnPGtGiRAbb",
+          "id" : "64M6ah0SkkRsnPGtGiRAbb",
+          "name" : "Bebe Rexha",
+          "type" : "artist",
+          "uri" : "spotify:artist:64M6ah0SkkRsnPGtGiRAbb"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/7M842DMhYVALrXsw3ty7B3"
+        },
+        "href" : "https://api.spotify.com/v1/albums/7M842DMhYVALrXsw3ty7B3",
+        "id" : "7M842DMhYVALrXsw3ty7B3",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273933c036cd61cd40d3f17a9c4",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02933c036cd61cd40d3f17a9c4",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851933c036cd61cd40d3f17a9c4",
+          "width" : 64
+        } ],
+        "name" : "I'm Good (Blue)",
+        "release_date" : "2022-08-26",
+        "release_date_precision" : "day",
+        "total_tracks" : 2,
+        "type" : "album",
+        "uri" : "spotify:album:7M842DMhYVALrXsw3ty7B3"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+        },
+        "href" : "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+        "id" : "1Cs0zKBU1kc0i8ypK3B9ai",
+        "name" : "David Guetta",
+        "type" : "artist",
+        "uri" : "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/64M6ah0SkkRsnPGtGiRAbb"
+        },
+        "href" : "https://api.spotify.com/v1/artists/64M6ah0SkkRsnPGtGiRAbb",
+        "id" : "64M6ah0SkkRsnPGtGiRAbb",
+        "name" : "Bebe Rexha",
+        "type" : "artist",
+        "uri" : "spotify:artist:64M6ah0SkkRsnPGtGiRAbb"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 175238,
+      "episode" : false,
+      "explicit" : true,
+      "external_ids" : {
+        "isrc" : "UKWLG2200055"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/4uUG5RXrOk84mYEfFvj3cK"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/4uUG5RXrOk84mYEfFvj3cK",
+      "id" : "4uUG5RXrOk84mYEfFvj3cK",
+      "is_local" : false,
+      "name" : "I'm Good (Blue)",
+      "popularity" : 93,
+      "preview_url" : "https://p.scdn.co/mp3-preview/f387f0bdbce0f044f7bf9e2e6a87f59cd78f20a4?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:4uUG5RXrOk84mYEfFvj3cK"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-06-10T12:29:27Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/5Pwc4xIPtQLFEnJriah9YJ"
+          },
+          "href" : "https://api.spotify.com/v1/artists/5Pwc4xIPtQLFEnJriah9YJ",
+          "id" : "5Pwc4xIPtQLFEnJriah9YJ",
+          "name" : "OneRepublic",
+          "type" : "artist",
+          "uri" : "spotify:artist:5Pwc4xIPtQLFEnJriah9YJ"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/04PEOM6kIEeq9lRp1asNP2"
+        },
+        "href" : "https://api.spotify.com/v1/albums/04PEOM6kIEeq9lRp1asNP2",
+        "id" : "04PEOM6kIEeq9lRp1asNP2",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273ec96e006b8bdfc582610ec13",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02ec96e006b8bdfc582610ec13",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851ec96e006b8bdfc582610ec13",
+          "width" : 64
+        } ],
+        "name" : "I Ain’t Worried (Music From The Motion Picture \"Top Gun: Maverick\")",
+        "release_date" : "2022-05-13",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:04PEOM6kIEeq9lRp1asNP2"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/5Pwc4xIPtQLFEnJriah9YJ"
+        },
+        "href" : "https://api.spotify.com/v1/artists/5Pwc4xIPtQLFEnJriah9YJ",
+        "id" : "5Pwc4xIPtQLFEnJriah9YJ",
+        "name" : "OneRepublic",
+        "type" : "artist",
+        "uri" : "spotify:artist:5Pwc4xIPtQLFEnJriah9YJ"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 148485,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "USUM72206227"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/4h9wh7iOZ0GGn8QVp4RAOB"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/4h9wh7iOZ0GGn8QVp4RAOB",
+      "id" : "4h9wh7iOZ0GGn8QVp4RAOB",
+      "is_local" : false,
+      "name" : "I Ain't Worried",
+      "popularity" : 95,
+      "preview_url" : "https://p.scdn.co/mp3-preview/657ab16e3f9b2d47ffbb2bc969db17ffcfc9198c?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:4h9wh7iOZ0GGn8QVp4RAOB"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-05-14T09:25:12Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/22wbnEMDvgVIAGdFeek6ET"
+          },
+          "href" : "https://api.spotify.com/v1/artists/22wbnEMDvgVIAGdFeek6ET",
+          "id" : "22wbnEMDvgVIAGdFeek6ET",
+          "name" : "Benson Boone",
+          "type" : "artist",
+          "uri" : "spotify:artist:22wbnEMDvgVIAGdFeek6ET"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/6dSmXsyGAnFtq048IFhiYd"
+        },
+        "href" : "https://api.spotify.com/v1/albums/6dSmXsyGAnFtq048IFhiYd",
+        "id" : "6dSmXsyGAnFtq048IFhiYd",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273786e4e2c43c2897fafabbfb6",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02786e4e2c43c2897fafabbfb6",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851786e4e2c43c2897fafabbfb6",
+          "width" : 64
+        } ],
+        "name" : "In The Stars",
+        "release_date" : "2022-04-29",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:6dSmXsyGAnFtq048IFhiYd"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/22wbnEMDvgVIAGdFeek6ET"
+        },
+        "href" : "https://api.spotify.com/v1/artists/22wbnEMDvgVIAGdFeek6ET",
+        "id" : "22wbnEMDvgVIAGdFeek6ET",
+        "name" : "Benson Boone",
+        "type" : "artist",
+        "uri" : "spotify:artist:22wbnEMDvgVIAGdFeek6ET"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 216410,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "USWB12201574"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/1ei3hzQmrgealgRKFxIcWn"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/1ei3hzQmrgealgRKFxIcWn",
+      "id" : "1ei3hzQmrgealgRKFxIcWn",
+      "is_local" : false,
+      "name" : "In The Stars",
+      "popularity" : 86,
+      "preview_url" : "https://p.scdn.co/mp3-preview/f1266c8f300a0b5a08107834a41cd069d4fb36e1?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:1ei3hzQmrgealgRKFxIcWn"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-05-27T18:07:01Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/0d1nFNO90pwRmCeeqjOx2Q"
+          },
+          "href" : "https://api.spotify.com/v1/artists/0d1nFNO90pwRmCeeqjOx2Q",
+          "id" : "0d1nFNO90pwRmCeeqjOx2Q",
+          "name" : "DI-RECT",
+          "type" : "artist",
+          "uri" : "spotify:artist:0d1nFNO90pwRmCeeqjOx2Q"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/5F9Y7Rx1ILWqQQXVilf0KN"
+        },
+        "href" : "https://api.spotify.com/v1/albums/5F9Y7Rx1ILWqQQXVilf0KN",
+        "id" : "5F9Y7Rx1ILWqQQXVilf0KN",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b2733ce1f2c275ee2ed593e1bd18",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e023ce1f2c275ee2ed593e1bd18",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d000048513ce1f2c275ee2ed593e1bd18",
+          "width" : 64
+        } ],
+        "name" : "Through The Looking Glass",
+        "release_date" : "2022-04-01",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:5F9Y7Rx1ILWqQQXVilf0KN"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/0d1nFNO90pwRmCeeqjOx2Q"
+        },
+        "href" : "https://api.spotify.com/v1/artists/0d1nFNO90pwRmCeeqjOx2Q",
+        "id" : "0d1nFNO90pwRmCeeqjOx2Q",
+        "name" : "DI-RECT",
+        "type" : "artist",
+        "uri" : "spotify:artist:0d1nFNO90pwRmCeeqjOx2Q"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 229761,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "NLZ292200041"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/7j2TJXhcE1aAzB6Evmgvm0"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/7j2TJXhcE1aAzB6Evmgvm0",
+      "id" : "7j2TJXhcE1aAzB6Evmgvm0",
+      "is_local" : false,
+      "name" : "Through The Looking Glass",
+      "popularity" : 67,
+      "preview_url" : "https://p.scdn.co/mp3-preview/2c45bde0ba4948713fe1b3a06f5575478fe69fbe?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:7j2TJXhcE1aAzB6Evmgvm0"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-06-10T12:29:22Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/0vhJymgsCubfAfFjEGVsoD"
+          },
+          "href" : "https://api.spotify.com/v1/artists/0vhJymgsCubfAfFjEGVsoD",
+          "id" : "0vhJymgsCubfAfFjEGVsoD",
+          "name" : "La Fuente",
+          "type" : "artist",
+          "uri" : "spotify:artist:0vhJymgsCubfAfFjEGVsoD"
+        } ],
+        "available_markets" : [ "BE", "CW", "LU", "NL" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/2e0yXV8bjdl4cqWwp1KG8T"
+        },
+        "href" : "https://api.spotify.com/v1/albums/2e0yXV8bjdl4cqWwp1KG8T",
+        "id" : "2e0yXV8bjdl4cqWwp1KG8T",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b2732410f22c48ab0a95e6629051",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e022410f22c48ab0a95e6629051",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d000048512410f22c48ab0a95e6629051",
+          "width" : 64
+        } ],
+        "name" : "I Want You",
+        "release_date" : "2022-04-15",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:2e0yXV8bjdl4cqWwp1KG8T"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/0vhJymgsCubfAfFjEGVsoD"
+        },
+        "href" : "https://api.spotify.com/v1/artists/0vhJymgsCubfAfFjEGVsoD",
+        "id" : "0vhJymgsCubfAfFjEGVsoD",
+        "name" : "La Fuente",
+        "type" : "artist",
+        "uri" : "spotify:artist:0vhJymgsCubfAfFjEGVsoD"
+      } ],
+      "available_markets" : [ "BE", "CW", "LU", "NL" ],
+      "disc_number" : 1,
+      "duration_ms" : 219401,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "NLQ8D2200237"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/4s8BpmFtxDgeCoPj2XHtVj"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/4s8BpmFtxDgeCoPj2XHtVj",
+      "id" : "4s8BpmFtxDgeCoPj2XHtVj",
+      "is_local" : false,
+      "name" : "I Want You",
+      "popularity" : 74,
+      "preview_url" : "https://p.scdn.co/mp3-preview/98043486fdf860d40f746740c19a5d8ea07e4c36?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:4s8BpmFtxDgeCoPj2XHtVj"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-04-08T15:37:05Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/6KImCVD70vtIoJWnq6nGn3"
+          },
+          "href" : "https://api.spotify.com/v1/artists/6KImCVD70vtIoJWnq6nGn3",
+          "id" : "6KImCVD70vtIoJWnq6nGn3",
+          "name" : "Harry Styles",
+          "type" : "artist",
+          "uri" : "spotify:artist:6KImCVD70vtIoJWnq6nGn3"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/2pqdSWeJVsXAhHFuVLzuA8"
+        },
+        "href" : "https://api.spotify.com/v1/albums/2pqdSWeJVsXAhHFuVLzuA8",
+        "id" : "2pqdSWeJVsXAhHFuVLzuA8",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273b46f74097655d7f353caab14",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02b46f74097655d7f353caab14",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851b46f74097655d7f353caab14",
+          "width" : 64
+        } ],
+        "name" : "As It Was",
+        "release_date" : "2022-03-31",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:2pqdSWeJVsXAhHFuVLzuA8"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/6KImCVD70vtIoJWnq6nGn3"
+        },
+        "href" : "https://api.spotify.com/v1/artists/6KImCVD70vtIoJWnq6nGn3",
+        "id" : "6KImCVD70vtIoJWnq6nGn3",
+        "name" : "Harry Styles",
+        "type" : "artist",
+        "uri" : "spotify:artist:6KImCVD70vtIoJWnq6nGn3"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 167303,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "USSM12200612"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/4LRPiXqCikLlN15c3yImP7"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/4LRPiXqCikLlN15c3yImP7",
+      "id" : "4LRPiXqCikLlN15c3yImP7",
+      "is_local" : false,
+      "name" : "As It Was",
+      "popularity" : 96,
+      "preview_url" : "https://p.scdn.co/mp3-preview/c871f7a3b36ad708640a833fbf7a0b9e84c5b688?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:4LRPiXqCikLlN15c3yImP7"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-08-05T15:27:58Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/0xRXCcSX89eobfrshSVdyu"
+          },
+          "href" : "https://api.spotify.com/v1/artists/0xRXCcSX89eobfrshSVdyu",
+          "id" : "0xRXCcSX89eobfrshSVdyu",
+          "name" : "MEDUZA",
+          "type" : "artist",
+          "uri" : "spotify:artist:0xRXCcSX89eobfrshSVdyu"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/5344K3N7rx7kw1HjO8psuq"
+          },
+          "href" : "https://api.spotify.com/v1/artists/5344K3N7rx7kw1HjO8psuq",
+          "id" : "5344K3N7rx7kw1HjO8psuq",
+          "name" : "James Carter",
+          "type" : "artist",
+          "uri" : "spotify:artist:5344K3N7rx7kw1HjO8psuq"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/67MNhiAICFY6Pwc2YxCO0K"
+          },
+          "href" : "https://api.spotify.com/v1/artists/67MNhiAICFY6Pwc2YxCO0K",
+          "id" : "67MNhiAICFY6Pwc2YxCO0K",
+          "name" : "Elley Duhé",
+          "type" : "artist",
+          "uri" : "spotify:artist:67MNhiAICFY6Pwc2YxCO0K"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/44aG7QLYLGotCTlu5Fc2J7"
+        },
+        "href" : "https://api.spotify.com/v1/albums/44aG7QLYLGotCTlu5Fc2J7",
+        "id" : "44aG7QLYLGotCTlu5Fc2J7",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b27320abd13bf81d8ee406827c38",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e0220abd13bf81d8ee406827c38",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d0000485120abd13bf81d8ee406827c38",
+          "width" : 64
+        } ],
+        "name" : "Bad Memories (feat. Elley Duhé & FAST BOY)",
+        "release_date" : "2022-07-22",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:44aG7QLYLGotCTlu5Fc2J7"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/0xRXCcSX89eobfrshSVdyu"
+        },
+        "href" : "https://api.spotify.com/v1/artists/0xRXCcSX89eobfrshSVdyu",
+        "id" : "0xRXCcSX89eobfrshSVdyu",
+        "name" : "MEDUZA",
+        "type" : "artist",
+        "uri" : "spotify:artist:0xRXCcSX89eobfrshSVdyu"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/5344K3N7rx7kw1HjO8psuq"
+        },
+        "href" : "https://api.spotify.com/v1/artists/5344K3N7rx7kw1HjO8psuq",
+        "id" : "5344K3N7rx7kw1HjO8psuq",
+        "name" : "James Carter",
+        "type" : "artist",
+        "uri" : "spotify:artist:5344K3N7rx7kw1HjO8psuq"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/67MNhiAICFY6Pwc2YxCO0K"
+        },
+        "href" : "https://api.spotify.com/v1/artists/67MNhiAICFY6Pwc2YxCO0K",
+        "id" : "67MNhiAICFY6Pwc2YxCO0K",
+        "name" : "Elley Duhé",
+        "type" : "artist",
+        "uri" : "spotify:artist:67MNhiAICFY6Pwc2YxCO0K"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/56Qz2XwGj7FxnNKrfkWjnb"
+        },
+        "href" : "https://api.spotify.com/v1/artists/56Qz2XwGj7FxnNKrfkWjnb",
+        "id" : "56Qz2XwGj7FxnNKrfkWjnb",
+        "name" : "FAST BOY",
+        "type" : "artist",
+        "uri" : "spotify:artist:56Qz2XwGj7FxnNKrfkWjnb"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 148629,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "GBUM72203666"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/3rb0tMq42WfggucPm0HHkA"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/3rb0tMq42WfggucPm0HHkA",
+      "id" : "3rb0tMq42WfggucPm0HHkA",
+      "is_local" : false,
+      "name" : "Bad Memories (feat. Elley Duhé & FAST BOY)",
+      "popularity" : 83,
+      "preview_url" : "https://p.scdn.co/mp3-preview/d8f12e1577a789068b3feb93963fa9ffa2580519?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:3rb0tMq42WfggucPm0HHkA"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-07-15T19:37:30Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/0HxX6imltnNXJyQhu4nsiO"
+          },
+          "href" : "https://api.spotify.com/v1/artists/0HxX6imltnNXJyQhu4nsiO",
+          "id" : "0HxX6imltnNXJyQhu4nsiO",
+          "name" : "LF SYSTEM",
+          "type" : "artist",
+          "uri" : "spotify:artist:0HxX6imltnNXJyQhu4nsiO"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/528LrHfHcB7PMAvyp8Obhp"
+        },
+        "href" : "https://api.spotify.com/v1/albums/528LrHfHcB7PMAvyp8Obhp",
+        "id" : "528LrHfHcB7PMAvyp8Obhp",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273ced808ef1567eaf901041438",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02ced808ef1567eaf901041438",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851ced808ef1567eaf901041438",
+          "width" : 64
+        } ],
+        "name" : "Afraid To Feel",
+        "release_date" : "2022-05-02",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:528LrHfHcB7PMAvyp8Obhp"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/0HxX6imltnNXJyQhu4nsiO"
+        },
+        "href" : "https://api.spotify.com/v1/artists/0HxX6imltnNXJyQhu4nsiO",
+        "id" : "0HxX6imltnNXJyQhu4nsiO",
+        "name" : "LF SYSTEM",
+        "type" : "artist",
+        "uri" : "spotify:artist:0HxX6imltnNXJyQhu4nsiO"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 177524,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "GBAHT2200492"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/40SBS57su9xLiE1WqkXOVr"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/40SBS57su9xLiE1WqkXOVr",
+      "id" : "40SBS57su9xLiE1WqkXOVr",
+      "is_local" : false,
+      "name" : "Afraid To Feel",
+      "popularity" : 86,
+      "preview_url" : "https://p.scdn.co/mp3-preview/127d8691ff65a9c521813cbfb973ac5302b7840f?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:40SBS57su9xLiE1WqkXOVr"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-07-15T19:37:50Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/2urF8dgLVfDjunO0pcHUEe"
+          },
+          "href" : "https://api.spotify.com/v1/artists/2urF8dgLVfDjunO0pcHUEe",
+          "id" : "2urF8dgLVfDjunO0pcHUEe",
+          "name" : "Alvaro Soler",
+          "type" : "artist",
+          "uri" : "spotify:artist:2urF8dgLVfDjunO0pcHUEe"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/0u6GtibW46tFX7koQ6uNJZ"
+          },
+          "href" : "https://api.spotify.com/v1/artists/0u6GtibW46tFX7koQ6uNJZ",
+          "id" : "0u6GtibW46tFX7koQ6uNJZ",
+          "name" : "Topic",
+          "type" : "artist",
+          "uri" : "spotify:artist:0u6GtibW46tFX7koQ6uNJZ"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/7CX6KwcrRx0iwTH8iU6rDJ"
+        },
+        "href" : "https://api.spotify.com/v1/albums/7CX6KwcrRx0iwTH8iU6rDJ",
+        "id" : "7CX6KwcrRx0iwTH8iU6rDJ",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273834cabf60b171236adde4126",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02834cabf60b171236adde4126",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851834cabf60b171236adde4126",
+          "width" : 64
+        } ],
+        "name" : "Solo Para Ti",
+        "release_date" : "2022-04-22",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:7CX6KwcrRx0iwTH8iU6rDJ"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/2urF8dgLVfDjunO0pcHUEe"
+        },
+        "href" : "https://api.spotify.com/v1/artists/2urF8dgLVfDjunO0pcHUEe",
+        "id" : "2urF8dgLVfDjunO0pcHUEe",
+        "name" : "Alvaro Soler",
+        "type" : "artist",
+        "uri" : "spotify:artist:2urF8dgLVfDjunO0pcHUEe"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/0u6GtibW46tFX7koQ6uNJZ"
+        },
+        "href" : "https://api.spotify.com/v1/artists/0u6GtibW46tFX7koQ6uNJZ",
+        "id" : "0u6GtibW46tFX7koQ6uNJZ",
+        "name" : "Topic",
+        "type" : "artist",
+        "uri" : "spotify:artist:0u6GtibW46tFX7koQ6uNJZ"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 198106,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "DEUM72201943"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/2uAgZ0PelSImQe3BME9CiT"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/2uAgZ0PelSImQe3BME9CiT",
+      "id" : "2uAgZ0PelSImQe3BME9CiT",
+      "is_local" : false,
+      "name" : "Solo Para Ti",
+      "popularity" : 74,
+      "preview_url" : "https://p.scdn.co/mp3-preview/7e5a6ad166f03f9ad87e903fb3b660f65033c10a?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:2uAgZ0PelSImQe3BME9CiT"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-05-06T15:40:40Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/0YLlTW9rW7ZCy2cA2u3RYk"
+          },
+          "href" : "https://api.spotify.com/v1/artists/0YLlTW9rW7ZCy2cA2u3RYk",
+          "id" : "0YLlTW9rW7ZCy2cA2u3RYk",
+          "name" : "FLEMMING",
+          "type" : "artist",
+          "uri" : "spotify:artist:0YLlTW9rW7ZCy2cA2u3RYk"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/1ORFwaAJM7agyaN1ZLiUHs"
+        },
+        "href" : "https://api.spotify.com/v1/albums/1ORFwaAJM7agyaN1ZLiUHs",
+        "id" : "1ORFwaAJM7agyaN1ZLiUHs",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273dc3baf87ca57d3097d12287f",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02dc3baf87ca57d3097d12287f",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851dc3baf87ca57d3097d12287f",
+          "width" : 64
+        } ],
+        "name" : "Automatisch",
+        "release_date" : "2022-04-29",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:1ORFwaAJM7agyaN1ZLiUHs"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/0YLlTW9rW7ZCy2cA2u3RYk"
+        },
+        "href" : "https://api.spotify.com/v1/artists/0YLlTW9rW7ZCy2cA2u3RYk",
+        "id" : "0YLlTW9rW7ZCy2cA2u3RYk",
+        "name" : "FLEMMING",
+        "type" : "artist",
+        "uri" : "spotify:artist:0YLlTW9rW7ZCy2cA2u3RYk"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 165768,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "NLZ292200042"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/2WeAyT93f7IzrwXm3ZJMb2"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/2WeAyT93f7IzrwXm3ZJMb2",
+      "id" : "2WeAyT93f7IzrwXm3ZJMb2",
+      "is_local" : false,
+      "name" : "Automatisch",
+      "popularity" : 73,
+      "preview_url" : "https://p.scdn.co/mp3-preview/88a9616bac622b761f5808de2ecbd06b43c2b0ad?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:2WeAyT93f7IzrwXm3ZJMb2"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-07-29T16:48:37Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/0NGAZxHanS9e0iNHpR8f2W"
+          },
+          "href" : "https://api.spotify.com/v1/artists/0NGAZxHanS9e0iNHpR8f2W",
+          "id" : "0NGAZxHanS9e0iNHpR8f2W",
+          "name" : "Alok",
+          "type" : "artist",
+          "uri" : "spotify:artist:0NGAZxHanS9e0iNHpR8f2W"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/66TrUkUZ3RM29dqeDQRgyA"
+          },
+          "href" : "https://api.spotify.com/v1/artists/66TrUkUZ3RM29dqeDQRgyA",
+          "id" : "66TrUkUZ3RM29dqeDQRgyA",
+          "name" : "Ella Eyre",
+          "type" : "artist",
+          "uri" : "spotify:artist:66TrUkUZ3RM29dqeDQRgyA"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/1TrfxjXu8quyDw05p2bacX"
+          },
+          "href" : "https://api.spotify.com/v1/artists/1TrfxjXu8quyDw05p2bacX",
+          "id" : "1TrfxjXu8quyDw05p2bacX",
+          "name" : "Kenny Dope",
+          "type" : "artist",
+          "uri" : "spotify:artist:1TrfxjXu8quyDw05p2bacX"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/3KpxpdySrMR2S7noneu1bI"
+        },
+        "href" : "https://api.spotify.com/v1/albums/3KpxpdySrMR2S7noneu1bI",
+        "id" : "3KpxpdySrMR2S7noneu1bI",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273ed443f0fff29eee63c9ede20",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02ed443f0fff29eee63c9ede20",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851ed443f0fff29eee63c9ede20",
+          "width" : 64
+        } ],
+        "name" : "Deep Down (feat. Never Dull)",
+        "release_date" : "2022-06-17",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:3KpxpdySrMR2S7noneu1bI"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/0NGAZxHanS9e0iNHpR8f2W"
+        },
+        "href" : "https://api.spotify.com/v1/artists/0NGAZxHanS9e0iNHpR8f2W",
+        "id" : "0NGAZxHanS9e0iNHpR8f2W",
+        "name" : "Alok",
+        "type" : "artist",
+        "uri" : "spotify:artist:0NGAZxHanS9e0iNHpR8f2W"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/66TrUkUZ3RM29dqeDQRgyA"
+        },
+        "href" : "https://api.spotify.com/v1/artists/66TrUkUZ3RM29dqeDQRgyA",
+        "id" : "66TrUkUZ3RM29dqeDQRgyA",
+        "name" : "Ella Eyre",
+        "type" : "artist",
+        "uri" : "spotify:artist:66TrUkUZ3RM29dqeDQRgyA"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/1TrfxjXu8quyDw05p2bacX"
+        },
+        "href" : "https://api.spotify.com/v1/artists/1TrfxjXu8quyDw05p2bacX",
+        "id" : "1TrfxjXu8quyDw05p2bacX",
+        "name" : "Kenny Dope",
+        "type" : "artist",
+        "uri" : "spotify:artist:1TrfxjXu8quyDw05p2bacX"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/2u3rmzZC0psTER2sDfUebm"
+        },
+        "href" : "https://api.spotify.com/v1/artists/2u3rmzZC0psTER2sDfUebm",
+        "id" : "2u3rmzZC0psTER2sDfUebm",
+        "name" : "Never Dull",
+        "type" : "artist",
+        "uri" : "spotify:artist:2u3rmzZC0psTER2sDfUebm"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 165752,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "DEE862200810"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/7MIhUdNJtaOnDmC5nBC1fb"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/7MIhUdNJtaOnDmC5nBC1fb",
+      "id" : "7MIhUdNJtaOnDmC5nBC1fb",
+      "is_local" : false,
+      "name" : "Deep Down (feat. Never Dull)",
+      "popularity" : 84,
+      "preview_url" : "https://p.scdn.co/mp3-preview/b4d439ac9a810e7d2a47f0eb9d2cca1341799398?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:7MIhUdNJtaOnDmC5nBC1fb"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-05-06T15:40:33Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/2ysnwxxNtSgbb9t1m2Ur4j"
+          },
+          "href" : "https://api.spotify.com/v1/artists/2ysnwxxNtSgbb9t1m2Ur4j",
+          "id" : "2ysnwxxNtSgbb9t1m2Ur4j",
+          "name" : "George Ezra",
+          "type" : "artist",
+          "uri" : "spotify:artist:2ysnwxxNtSgbb9t1m2Ur4j"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/1p6j020MWD6BCELPZd8XVC"
+        },
+        "href" : "https://api.spotify.com/v1/albums/1p6j020MWD6BCELPZd8XVC",
+        "id" : "1p6j020MWD6BCELPZd8XVC",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273e8a6aeabb9c999341e2c405c",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02e8a6aeabb9c999341e2c405c",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851e8a6aeabb9c999341e2c405c",
+          "width" : 64
+        } ],
+        "name" : "Green Green Grass",
+        "release_date" : "2022-04-22",
+        "release_date_precision" : "day",
+        "total_tracks" : 2,
+        "type" : "album",
+        "uri" : "spotify:album:1p6j020MWD6BCELPZd8XVC"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/2ysnwxxNtSgbb9t1m2Ur4j"
+        },
+        "href" : "https://api.spotify.com/v1/artists/2ysnwxxNtSgbb9t1m2Ur4j",
+        "id" : "2ysnwxxNtSgbb9t1m2Ur4j",
+        "name" : "George Ezra",
+        "type" : "artist",
+        "uri" : "spotify:artist:2ysnwxxNtSgbb9t1m2Ur4j"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 167613,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "GBARL2200008"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/3rk4aJ0vAj3cFUIQEeASkT"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/3rk4aJ0vAj3cFUIQEeASkT",
+      "id" : "3rk4aJ0vAj3cFUIQEeASkT",
+      "is_local" : false,
+      "name" : "Green Green Grass",
+      "popularity" : 78,
+      "preview_url" : "https://p.scdn.co/mp3-preview/b1212f91d1c4a4a488636877be16cf610ab8aa18?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:3rk4aJ0vAj3cFUIQEeASkT"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-07-08T15:53:05Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/2o5jDhtHVPhrJdv3cEQ99Z"
+          },
+          "href" : "https://api.spotify.com/v1/artists/2o5jDhtHVPhrJdv3cEQ99Z",
+          "id" : "2o5jDhtHVPhrJdv3cEQ99Z",
+          "name" : "Tiësto",
+          "type" : "artist",
+          "uri" : "spotify:artist:2o5jDhtHVPhrJdv3cEQ99Z"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/25uiPmTg16RbhZWAqwLBy5"
+          },
+          "href" : "https://api.spotify.com/v1/artists/25uiPmTg16RbhZWAqwLBy5",
+          "id" : "25uiPmTg16RbhZWAqwLBy5",
+          "name" : "Charli XCX",
+          "type" : "artist",
+          "uri" : "spotify:artist:25uiPmTg16RbhZWAqwLBy5"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/6R7Yy0sY9N8PNUhseegr2Q"
+        },
+        "href" : "https://api.spotify.com/v1/albums/6R7Yy0sY9N8PNUhseegr2Q",
+        "id" : "6R7Yy0sY9N8PNUhseegr2Q",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b2731e8798f25a1997f0679b2382",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e021e8798f25a1997f0679b2382",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d000048511e8798f25a1997f0679b2382",
+          "width" : 64
+        } ],
+        "name" : "Hot In It",
+        "release_date" : "2022-06-30",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:6R7Yy0sY9N8PNUhseegr2Q"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/2o5jDhtHVPhrJdv3cEQ99Z"
+        },
+        "href" : "https://api.spotify.com/v1/artists/2o5jDhtHVPhrJdv3cEQ99Z",
+        "id" : "2o5jDhtHVPhrJdv3cEQ99Z",
+        "name" : "Tiësto",
+        "type" : "artist",
+        "uri" : "spotify:artist:2o5jDhtHVPhrJdv3cEQ99Z"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/25uiPmTg16RbhZWAqwLBy5"
+        },
+        "href" : "https://api.spotify.com/v1/artists/25uiPmTg16RbhZWAqwLBy5",
+        "id" : "25uiPmTg16RbhZWAqwLBy5",
+        "name" : "Charli XCX",
+        "type" : "artist",
+        "uri" : "spotify:artist:25uiPmTg16RbhZWAqwLBy5"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 129817,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "CYA112001102"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/3Z7CaxQkqbIs1rewKi6v4W"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/3Z7CaxQkqbIs1rewKi6v4W",
+      "id" : "3Z7CaxQkqbIs1rewKi6v4W",
+      "is_local" : false,
+      "name" : "Hot In It",
+      "popularity" : 84,
+      "preview_url" : "https://p.scdn.co/mp3-preview/a0fe8100d40b910d568d2ae2c281925716d25b3d?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:3Z7CaxQkqbIs1rewKi6v4W"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-08-26T15:59:08Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/4xDh11zptvPADSQxvbiClo"
+          },
+          "href" : "https://api.spotify.com/v1/artists/4xDh11zptvPADSQxvbiClo",
+          "id" : "4xDh11zptvPADSQxvbiClo",
+          "name" : "KATNUF",
+          "type" : "artist",
+          "uri" : "spotify:artist:4xDh11zptvPADSQxvbiClo"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/4umTGjL6WgGnfoJWgz1uHe"
+        },
+        "href" : "https://api.spotify.com/v1/albums/4umTGjL6WgGnfoJWgz1uHe",
+        "id" : "4umTGjL6WgGnfoJWgz1uHe",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b27353ad4d89052c295cbc5609a3",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e0253ad4d89052c295cbc5609a3",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d0000485153ad4d89052c295cbc5609a3",
+          "width" : 64
+        } ],
+        "name" : "Van Mij Zijn",
+        "release_date" : "2022-08-11",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:4umTGjL6WgGnfoJWgz1uHe"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/4xDh11zptvPADSQxvbiClo"
+        },
+        "href" : "https://api.spotify.com/v1/artists/4xDh11zptvPADSQxvbiClo",
+        "id" : "4xDh11zptvPADSQxvbiClo",
+        "name" : "KATNUF",
+        "type" : "artist",
+        "uri" : "spotify:artist:4xDh11zptvPADSQxvbiClo"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 166911,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "NLP762200119"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/3oFKhY9iW9S0iA9OHO9tN6"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/3oFKhY9iW9S0iA9OHO9tN6",
+      "id" : "3oFKhY9iW9S0iA9OHO9tN6",
+      "is_local" : false,
+      "name" : "Van Mij Zijn",
+      "popularity" : 76,
+      "preview_url" : "https://p.scdn.co/mp3-preview/c4c09b9cf4dc4a3f1d1fffc6e6d86617f09426b8?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:3oFKhY9iW9S0iA9OHO9tN6"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-04-29T15:46:14Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/0SfsnGyD8FpIN4U4WCkBZ5"
+          },
+          "href" : "https://api.spotify.com/v1/artists/0SfsnGyD8FpIN4U4WCkBZ5",
+          "id" : "0SfsnGyD8FpIN4U4WCkBZ5",
+          "name" : "Armin van Buuren",
+          "type" : "artist",
+          "uri" : "spotify:artist:0SfsnGyD8FpIN4U4WCkBZ5"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/5PoZtBo8xZKqPWlZrIDq82"
+          },
+          "href" : "https://api.spotify.com/v1/artists/5PoZtBo8xZKqPWlZrIDq82",
+          "id" : "5PoZtBo8xZKqPWlZrIDq82",
+          "name" : "Billen Ted",
+          "type" : "artist",
+          "uri" : "spotify:artist:5PoZtBo8xZKqPWlZrIDq82"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/2TAqN8fwfaKauvviN4pOsv"
+          },
+          "href" : "https://api.spotify.com/v1/artists/2TAqN8fwfaKauvviN4pOsv",
+          "id" : "2TAqN8fwfaKauvviN4pOsv",
+          "name" : "JC Stewart",
+          "type" : "artist",
+          "uri" : "spotify:artist:2TAqN8fwfaKauvviN4pOsv"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CD", "CG", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/312M1zzN7C2Vqd0VeORTMC"
+        },
+        "href" : "https://api.spotify.com/v1/albums/312M1zzN7C2Vqd0VeORTMC",
+        "id" : "312M1zzN7C2Vqd0VeORTMC",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b2732e6ac880b264e7e2aab46fb2",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e022e6ac880b264e7e2aab46fb2",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d000048512e6ac880b264e7e2aab46fb2",
+          "width" : 64
+        } ],
+        "name" : "Come Around Again",
+        "release_date" : "2022-04-08",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:312M1zzN7C2Vqd0VeORTMC"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/0SfsnGyD8FpIN4U4WCkBZ5"
+        },
+        "href" : "https://api.spotify.com/v1/artists/0SfsnGyD8FpIN4U4WCkBZ5",
+        "id" : "0SfsnGyD8FpIN4U4WCkBZ5",
+        "name" : "Armin van Buuren",
+        "type" : "artist",
+        "uri" : "spotify:artist:0SfsnGyD8FpIN4U4WCkBZ5"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/5PoZtBo8xZKqPWlZrIDq82"
+        },
+        "href" : "https://api.spotify.com/v1/artists/5PoZtBo8xZKqPWlZrIDq82",
+        "id" : "5PoZtBo8xZKqPWlZrIDq82",
+        "name" : "Billen Ted",
+        "type" : "artist",
+        "uri" : "spotify:artist:5PoZtBo8xZKqPWlZrIDq82"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/2TAqN8fwfaKauvviN4pOsv"
+        },
+        "href" : "https://api.spotify.com/v1/artists/2TAqN8fwfaKauvviN4pOsv",
+        "id" : "2TAqN8fwfaKauvviN4pOsv",
+        "name" : "JC Stewart",
+        "type" : "artist",
+        "uri" : "spotify:artist:2TAqN8fwfaKauvviN4pOsv"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CD", "CG", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 169108,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "NLF712202338"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/55Y4oE6oE6XBT2e71vK2yA"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/55Y4oE6oE6XBT2e71vK2yA",
+      "id" : "55Y4oE6oE6XBT2e71vK2yA",
+      "is_local" : false,
+      "name" : "Come Around Again",
+      "popularity" : 66,
+      "preview_url" : "https://p.scdn.co/mp3-preview/ce230bc8445dc9ff15f7dc23eeb27bc2e2e25ace?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:55Y4oE6oE6XBT2e71vK2yA"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-07-01T14:51:24Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/5ENS85nZShljwNgg4wFD7D"
+          },
+          "href" : "https://api.spotify.com/v1/artists/5ENS85nZShljwNgg4wFD7D",
+          "id" : "5ENS85nZShljwNgg4wFD7D",
+          "name" : "Gabry Ponte",
+          "type" : "artist",
+          "uri" : "spotify:artist:5ENS85nZShljwNgg4wFD7D"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/0TKFPt9w0AAEnhB9bd0pLy"
+          },
+          "href" : "https://api.spotify.com/v1/artists/0TKFPt9w0AAEnhB9bd0pLy",
+          "id" : "0TKFPt9w0AAEnhB9bd0pLy",
+          "name" : "LUM!X",
+          "type" : "artist",
+          "uri" : "spotify:artist:0TKFPt9w0AAEnhB9bd0pLy"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/2Bc52Zzq4Hx7Dqm0Qw8bJL"
+          },
+          "href" : "https://api.spotify.com/v1/artists/2Bc52Zzq4Hx7Dqm0Qw8bJL",
+          "id" : "2Bc52Zzq4Hx7Dqm0Qw8bJL",
+          "name" : "Daddy DJ",
+          "type" : "artist",
+          "uri" : "spotify:artist:2Bc52Zzq4Hx7Dqm0Qw8bJL"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/7xgmfo0gHFJk9DNdOfqBNn"
+        },
+        "href" : "https://api.spotify.com/v1/albums/7xgmfo0gHFJk9DNdOfqBNn",
+        "id" : "7xgmfo0gHFJk9DNdOfqBNn",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b2735f0accf6c25a36d5998691a7",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e025f0accf6c25a36d5998691a7",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d000048515f0accf6c25a36d5998691a7",
+          "width" : 64
+        } ],
+        "name" : "We Could Be Together (feat. Daddy DJ)",
+        "release_date" : "2022-06-03",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:7xgmfo0gHFJk9DNdOfqBNn"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/5ENS85nZShljwNgg4wFD7D"
+        },
+        "href" : "https://api.spotify.com/v1/artists/5ENS85nZShljwNgg4wFD7D",
+        "id" : "5ENS85nZShljwNgg4wFD7D",
+        "name" : "Gabry Ponte",
+        "type" : "artist",
+        "uri" : "spotify:artist:5ENS85nZShljwNgg4wFD7D"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/0TKFPt9w0AAEnhB9bd0pLy"
+        },
+        "href" : "https://api.spotify.com/v1/artists/0TKFPt9w0AAEnhB9bd0pLy",
+        "id" : "0TKFPt9w0AAEnhB9bd0pLy",
+        "name" : "LUM!X",
+        "type" : "artist",
+        "uri" : "spotify:artist:0TKFPt9w0AAEnhB9bd0pLy"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/2Bc52Zzq4Hx7Dqm0Qw8bJL"
+        },
+        "href" : "https://api.spotify.com/v1/artists/2Bc52Zzq4Hx7Dqm0Qw8bJL",
+        "id" : "2Bc52Zzq4Hx7Dqm0Qw8bJL",
+        "name" : "Daddy DJ",
+        "type" : "artist",
+        "uri" : "spotify:artist:2Bc52Zzq4Hx7Dqm0Qw8bJL"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 149642,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "ITV952200075"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/3ElGRG3DqSzzkh1b2wnbzf"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/3ElGRG3DqSzzkh1b2wnbzf",
+      "id" : "3ElGRG3DqSzzkh1b2wnbzf",
+      "is_local" : false,
+      "name" : "We Could Be Together (feat. Daddy DJ)",
+      "popularity" : 77,
+      "preview_url" : "https://p.scdn.co/mp3-preview/8b87e0a3fb6c73d2fda0bdeb5efb306d69078537?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:3ElGRG3DqSzzkh1b2wnbzf"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-06-03T15:01:54Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "album",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/6KImCVD70vtIoJWnq6nGn3"
+          },
+          "href" : "https://api.spotify.com/v1/artists/6KImCVD70vtIoJWnq6nGn3",
+          "id" : "6KImCVD70vtIoJWnq6nGn3",
+          "name" : "Harry Styles",
+          "type" : "artist",
+          "uri" : "spotify:artist:6KImCVD70vtIoJWnq6nGn3"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/5r36AJ6VOJtp00oxSkBZ5h"
+        },
+        "href" : "https://api.spotify.com/v1/albums/5r36AJ6VOJtp00oxSkBZ5h",
+        "id" : "5r36AJ6VOJtp00oxSkBZ5h",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b2732e8ed79e177ff6011076f5f0",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e022e8ed79e177ff6011076f5f0",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d000048512e8ed79e177ff6011076f5f0",
+          "width" : 64
+        } ],
+        "name" : "Harry's House",
+        "release_date" : "2022-05-20",
+        "release_date_precision" : "day",
+        "total_tracks" : 13,
+        "type" : "album",
+        "uri" : "spotify:album:5r36AJ6VOJtp00oxSkBZ5h"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/6KImCVD70vtIoJWnq6nGn3"
+        },
+        "href" : "https://api.spotify.com/v1/artists/6KImCVD70vtIoJWnq6nGn3",
+        "id" : "6KImCVD70vtIoJWnq6nGn3",
+        "name" : "Harry Styles",
+        "type" : "artist",
+        "uri" : "spotify:artist:6KImCVD70vtIoJWnq6nGn3"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 177954,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "USSM12200610"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/1qEmFfgcLObUfQm0j1W2CK"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/1qEmFfgcLObUfQm0j1W2CK",
+      "id" : "1qEmFfgcLObUfQm0j1W2CK",
+      "is_local" : false,
+      "name" : "Late Night Talking",
+      "popularity" : 93,
+      "preview_url" : "https://p.scdn.co/mp3-preview/ab3568a72e1c016308c263854dc307251ce33a2b?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 2,
+      "type" : "track",
+      "uri" : "spotify:track:1qEmFfgcLObUfQm0j1W2CK"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-09-02T17:11:18Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/3PhoLpVuITZKcymswpck5b"
+          },
+          "href" : "https://api.spotify.com/v1/artists/3PhoLpVuITZKcymswpck5b",
+          "id" : "3PhoLpVuITZKcymswpck5b",
+          "name" : "Elton John",
+          "type" : "artist",
+          "uri" : "spotify:artist:3PhoLpVuITZKcymswpck5b"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/26dSoYclwsYLMAKD3tpOr4"
+          },
+          "href" : "https://api.spotify.com/v1/artists/26dSoYclwsYLMAKD3tpOr4",
+          "id" : "26dSoYclwsYLMAKD3tpOr4",
+          "name" : "Britney Spears",
+          "type" : "artist",
+          "uri" : "spotify:artist:26dSoYclwsYLMAKD3tpOr4"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/4QQWpCEX4BxMXwRQmtkKY6"
+        },
+        "href" : "https://api.spotify.com/v1/albums/4QQWpCEX4BxMXwRQmtkKY6",
+        "id" : "4QQWpCEX4BxMXwRQmtkKY6",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b2735d872e7b0c1ba964541f07e8",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e025d872e7b0c1ba964541f07e8",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d000048515d872e7b0c1ba964541f07e8",
+          "width" : 64
+        } ],
+        "name" : "Hold Me Closer",
+        "release_date" : "2022-08-26",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:4QQWpCEX4BxMXwRQmtkKY6"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/3PhoLpVuITZKcymswpck5b"
+        },
+        "href" : "https://api.spotify.com/v1/artists/3PhoLpVuITZKcymswpck5b",
+        "id" : "3PhoLpVuITZKcymswpck5b",
+        "name" : "Elton John",
+        "type" : "artist",
+        "uri" : "spotify:artist:3PhoLpVuITZKcymswpck5b"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/26dSoYclwsYLMAKD3tpOr4"
+        },
+        "href" : "https://api.spotify.com/v1/artists/26dSoYclwsYLMAKD3tpOr4",
+        "id" : "26dSoYclwsYLMAKD3tpOr4",
+        "name" : "Britney Spears",
+        "type" : "artist",
+        "uri" : "spotify:artist:26dSoYclwsYLMAKD3tpOr4"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 202245,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "GBUM72205030"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/72yP0DUlWPyH8P7IoxskwN"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/72yP0DUlWPyH8P7IoxskwN",
+      "id" : "72yP0DUlWPyH8P7IoxskwN",
+      "is_local" : false,
+      "name" : "Hold Me Closer",
+      "popularity" : 88,
+      "preview_url" : "https://p.scdn.co/mp3-preview/20dbd2f390581eb21701397a07dcd94b38ae22ab?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:72yP0DUlWPyH8P7IoxskwN"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-04-15T15:57:00Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/43BxCL6t4c73BQnIJtry5v"
+          },
+          "href" : "https://api.spotify.com/v1/artists/43BxCL6t4c73BQnIJtry5v",
+          "id" : "43BxCL6t4c73BQnIJtry5v",
+          "name" : "James Hype",
+          "type" : "artist",
+          "uri" : "spotify:artist:43BxCL6t4c73BQnIJtry5v"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/45ruzGUmIr8WLjLOPJ9mGU"
+          },
+          "href" : "https://api.spotify.com/v1/artists/45ruzGUmIr8WLjLOPJ9mGU",
+          "id" : "45ruzGUmIr8WLjLOPJ9mGU",
+          "name" : "Miggy Dela Rosa",
+          "type" : "artist",
+          "uri" : "spotify:artist:45ruzGUmIr8WLjLOPJ9mGU"
+        } ],
+        "available_markets" : [ ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/4WLkmuc0lGCBJLtj1yxJI0"
+        },
+        "href" : "https://api.spotify.com/v1/albums/4WLkmuc0lGCBJLtj1yxJI0",
+        "id" : "4WLkmuc0lGCBJLtj1yxJI0",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273c9fde681213854ecd4265001",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02c9fde681213854ecd4265001",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851c9fde681213854ecd4265001",
+          "width" : 64
+        } ],
+        "name" : "Ferrari",
+        "release_date" : "2022-03-15",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:4WLkmuc0lGCBJLtj1yxJI0"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/43BxCL6t4c73BQnIJtry5v"
+        },
+        "href" : "https://api.spotify.com/v1/artists/43BxCL6t4c73BQnIJtry5v",
+        "id" : "43BxCL6t4c73BQnIJtry5v",
+        "name" : "James Hype",
+        "type" : "artist",
+        "uri" : "spotify:artist:43BxCL6t4c73BQnIJtry5v"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/45ruzGUmIr8WLjLOPJ9mGU"
+        },
+        "href" : "https://api.spotify.com/v1/artists/45ruzGUmIr8WLjLOPJ9mGU",
+        "id" : "45ruzGUmIr8WLjLOPJ9mGU",
+        "name" : "Miggy Dela Rosa",
+        "type" : "artist",
+        "uri" : "spotify:artist:45ruzGUmIr8WLjLOPJ9mGU"
+      } ],
+      "available_markets" : [ ],
+      "disc_number" : 1,
+      "duration_ms" : 185661,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "GB3CE2200004"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/5xKJI9aPQhuTdTq8BrJ8fL"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/5xKJI9aPQhuTdTq8BrJ8fL",
+      "id" : "5xKJI9aPQhuTdTq8BrJ8fL",
+      "is_local" : false,
+      "name" : "Ferrari",
+      "popularity" : 23,
+      "preview_url" : null,
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:5xKJI9aPQhuTdTq8BrJ8fL"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-08-12T15:13:43Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/3klZnJvYGIbWritVwQD434"
+          },
+          "href" : "https://api.spotify.com/v1/artists/3klZnJvYGIbWritVwQD434",
+          "id" : "3klZnJvYGIbWritVwQD434",
+          "name" : "Duncan Laurence",
+          "type" : "artist",
+          "uri" : "spotify:artist:3klZnJvYGIbWritVwQD434"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/0rgJvUPcgTDdiirvy7wHs6"
+        },
+        "href" : "https://api.spotify.com/v1/albums/0rgJvUPcgTDdiirvy7wHs6",
+        "id" : "0rgJvUPcgTDdiirvy7wHs6",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273d8ddeb06a5a6284c52aab434",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02d8ddeb06a5a6284c52aab434",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851d8ddeb06a5a6284c52aab434",
+          "width" : 64
+        } ],
+        "name" : "Electric Life",
+        "release_date" : "2022-08-03",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:0rgJvUPcgTDdiirvy7wHs6"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/3klZnJvYGIbWritVwQD434"
+        },
+        "href" : "https://api.spotify.com/v1/artists/3klZnJvYGIbWritVwQD434",
+        "id" : "3klZnJvYGIbWritVwQD434",
+        "name" : "Duncan Laurence",
+        "type" : "artist",
+        "uri" : "spotify:artist:3klZnJvYGIbWritVwQD434"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 194255,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "NL6NQ2200005"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/0iLqpm5c4dGlwth5LYq2tj"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/0iLqpm5c4dGlwth5LYq2tj",
+      "id" : "0iLqpm5c4dGlwth5LYq2tj",
+      "is_local" : false,
+      "name" : "Electric Life",
+      "popularity" : 65,
+      "preview_url" : "https://p.scdn.co/mp3-preview/22733a4683ecb655c5319d930c1b79f28387107c?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:0iLqpm5c4dGlwth5LYq2tj"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-03-25T16:41:23Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/4RSyJzf7ef6Iu2rnLdabNq"
+          },
+          "href" : "https://api.spotify.com/v1/artists/4RSyJzf7ef6Iu2rnLdabNq",
+          "id" : "4RSyJzf7ef6Iu2rnLdabNq",
+          "name" : "Willy William",
+          "type" : "artist",
+          "uri" : "spotify:artist:4RSyJzf7ef6Iu2rnLdabNq"
+        } ],
+        "available_markets" : [ "BE", "CW", "LU", "NL" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/6eEQ0sXVp92CmSL5SsfvY3"
+        },
+        "href" : "https://api.spotify.com/v1/albums/6eEQ0sXVp92CmSL5SsfvY3",
+        "id" : "6eEQ0sXVp92CmSL5SsfvY3",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b27315fce459a9d02d2110a8de94",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e0215fce459a9d02d2110a8de94",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d0000485115fce459a9d02d2110a8de94",
+          "width" : 64
+        } ],
+        "name" : "Trompeta",
+        "release_date" : "2022-02-18",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:6eEQ0sXVp92CmSL5SsfvY3"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/4RSyJzf7ef6Iu2rnLdabNq"
+        },
+        "href" : "https://api.spotify.com/v1/artists/4RSyJzf7ef6Iu2rnLdabNq",
+        "id" : "4RSyJzf7ef6Iu2rnLdabNq",
+        "name" : "Willy William",
+        "type" : "artist",
+        "uri" : "spotify:artist:4RSyJzf7ef6Iu2rnLdabNq"
+      } ],
+      "available_markets" : [ "BE", "CW", "LU", "NL" ],
+      "disc_number" : 1,
+      "duration_ms" : 168704,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "FR22F2200020"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/5cppeoXfiK59UEsEeOvuNo"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/5cppeoXfiK59UEsEeOvuNo",
+      "id" : "5cppeoXfiK59UEsEeOvuNo",
+      "is_local" : false,
+      "name" : "Trompeta",
+      "popularity" : 70,
+      "preview_url" : "https://p.scdn.co/mp3-preview/f290c1d5f3dcc67abd80908ab749a83063a27786?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:5cppeoXfiK59UEsEeOvuNo"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-06-17T15:37:10Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/7f5Zgnp2spUuuzKplmRkt7"
+          },
+          "href" : "https://api.spotify.com/v1/artists/7f5Zgnp2spUuuzKplmRkt7",
+          "id" : "7f5Zgnp2spUuuzKplmRkt7",
+          "name" : "Lost Frequencies",
+          "type" : "artist",
+          "uri" : "spotify:artist:7f5Zgnp2spUuuzKplmRkt7"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/4IWBUUAFIplrNtaOHcJPRM"
+          },
+          "href" : "https://api.spotify.com/v1/artists/4IWBUUAFIplrNtaOHcJPRM",
+          "id" : "4IWBUUAFIplrNtaOHcJPRM",
+          "name" : "James Arthur",
+          "type" : "artist",
+          "uri" : "spotify:artist:4IWBUUAFIplrNtaOHcJPRM"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/5HyQdrY2jAKPhK1OqX7yOR"
+        },
+        "href" : "https://api.spotify.com/v1/albums/5HyQdrY2jAKPhK1OqX7yOR",
+        "id" : "5HyQdrY2jAKPhK1OqX7yOR",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273a9ce58085d561eb5af353252",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02a9ce58085d561eb5af353252",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851a9ce58085d561eb5af353252",
+          "width" : 64
+        } ],
+        "name" : "Questions",
+        "release_date" : "2022-06-03",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:5HyQdrY2jAKPhK1OqX7yOR"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/7f5Zgnp2spUuuzKplmRkt7"
+        },
+        "href" : "https://api.spotify.com/v1/artists/7f5Zgnp2spUuuzKplmRkt7",
+        "id" : "7f5Zgnp2spUuuzKplmRkt7",
+        "name" : "Lost Frequencies",
+        "type" : "artist",
+        "uri" : "spotify:artist:7f5Zgnp2spUuuzKplmRkt7"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/4IWBUUAFIplrNtaOHcJPRM"
+        },
+        "href" : "https://api.spotify.com/v1/artists/4IWBUUAFIplrNtaOHcJPRM",
+        "id" : "4IWBUUAFIplrNtaOHcJPRM",
+        "name" : "James Arthur",
+        "type" : "artist",
+        "uri" : "spotify:artist:4IWBUUAFIplrNtaOHcJPRM"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 177156,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "BEHP42200001"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/1cgy2FSOQMbq7DHCVgMAUA"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/1cgy2FSOQMbq7DHCVgMAUA",
+      "id" : "1cgy2FSOQMbq7DHCVgMAUA",
+      "is_local" : false,
+      "name" : "Questions",
+      "popularity" : 77,
+      "preview_url" : "https://p.scdn.co/mp3-preview/af506811c66bef9f529ef7c2e44b3643e7563ce0?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:1cgy2FSOQMbq7DHCVgMAUA"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-07-24T11:25:14Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/2gduEC76ry33RVurAvT05p"
+          },
+          "href" : "https://api.spotify.com/v1/artists/2gduEC76ry33RVurAvT05p",
+          "id" : "2gduEC76ry33RVurAvT05p",
+          "name" : "Nathan Dawe",
+          "type" : "artist",
+          "uri" : "spotify:artist:2gduEC76ry33RVurAvT05p"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/7nDsS0l5ZAzMedVRKPP8F1"
+          },
+          "href" : "https://api.spotify.com/v1/artists/7nDsS0l5ZAzMedVRKPP8F1",
+          "id" : "7nDsS0l5ZAzMedVRKPP8F1",
+          "name" : "Ella Henderson",
+          "type" : "artist",
+          "uri" : "spotify:artist:7nDsS0l5ZAzMedVRKPP8F1"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/118PKNjhP4NWcrW5OjMwzc"
+        },
+        "href" : "https://api.spotify.com/v1/albums/118PKNjhP4NWcrW5OjMwzc",
+        "id" : "118PKNjhP4NWcrW5OjMwzc",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273ef126ba9057607d88e103904",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02ef126ba9057607d88e103904",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851ef126ba9057607d88e103904",
+          "width" : 64
+        } ],
+        "name" : "21 Reasons (feat. Ella Henderson)",
+        "release_date" : "2022-04-29",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:118PKNjhP4NWcrW5OjMwzc"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/2gduEC76ry33RVurAvT05p"
+        },
+        "href" : "https://api.spotify.com/v1/artists/2gduEC76ry33RVurAvT05p",
+        "id" : "2gduEC76ry33RVurAvT05p",
+        "name" : "Nathan Dawe",
+        "type" : "artist",
+        "uri" : "spotify:artist:2gduEC76ry33RVurAvT05p"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/7nDsS0l5ZAzMedVRKPP8F1"
+        },
+        "href" : "https://api.spotify.com/v1/artists/7nDsS0l5ZAzMedVRKPP8F1",
+        "id" : "7nDsS0l5ZAzMedVRKPP8F1",
+        "name" : "Ella Henderson",
+        "type" : "artist",
+        "uri" : "spotify:artist:7nDsS0l5ZAzMedVRKPP8F1"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 155253,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "GBAHS2200261"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/1RF02Cf80mTaeNXG2P2boR"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/1RF02Cf80mTaeNXG2P2boR",
+      "id" : "1RF02Cf80mTaeNXG2P2boR",
+      "is_local" : false,
+      "name" : "21 Reasons (feat. Ella Henderson)",
+      "popularity" : 84,
+      "preview_url" : "https://p.scdn.co/mp3-preview/61426412ad3f6689be2a87a4c818c48ed3c9fc6c?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:1RF02Cf80mTaeNXG2P2boR"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-09-09T15:35:48Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/77IW5ZK1smDQYYKDCQugXh"
+          },
+          "href" : "https://api.spotify.com/v1/artists/77IW5ZK1smDQYYKDCQugXh",
+          "id" : "77IW5ZK1smDQYYKDCQugXh",
+          "name" : "Suzan & Freek",
+          "type" : "artist",
+          "uri" : "spotify:artist:77IW5ZK1smDQYYKDCQugXh"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/3HdzIBLsdVX4RTuA4zxumb"
+        },
+        "href" : "https://api.spotify.com/v1/albums/3HdzIBLsdVX4RTuA4zxumb",
+        "id" : "3HdzIBLsdVX4RTuA4zxumb",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b27378824e1d10012983f2e7d3b3",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e0278824e1d10012983f2e7d3b3",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d0000485178824e1d10012983f2e7d3b3",
+          "width" : 64
+        } ],
+        "name" : "Kwijt",
+        "release_date" : "2022-09-01",
+        "release_date_precision" : "day",
+        "total_tracks" : 2,
+        "type" : "album",
+        "uri" : "spotify:album:3HdzIBLsdVX4RTuA4zxumb"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/77IW5ZK1smDQYYKDCQugXh"
+        },
+        "href" : "https://api.spotify.com/v1/artists/77IW5ZK1smDQYYKDCQugXh",
+        "id" : "77IW5ZK1smDQYYKDCQugXh",
+        "name" : "Suzan & Freek",
+        "type" : "artist",
+        "uri" : "spotify:artist:77IW5ZK1smDQYYKDCQugXh"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 195576,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "NL1CK2200003"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/1dbNg2ougivyUv6f9hQQzU"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/1dbNg2ougivyUv6f9hQQzU",
+      "id" : "1dbNg2ougivyUv6f9hQQzU",
+      "is_local" : false,
+      "name" : "Kwijt",
+      "popularity" : 66,
+      "preview_url" : "https://p.scdn.co/mp3-preview/eb236f45edd6d87095d735b16569d3a57d792ee2?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:1dbNg2ougivyUv6f9hQQzU"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-08-19T15:30:20Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/6DgP9otnZw5z6daOntINxp"
+          },
+          "href" : "https://api.spotify.com/v1/artists/6DgP9otnZw5z6daOntINxp",
+          "id" : "6DgP9otnZw5z6daOntINxp",
+          "name" : "Joel Corry",
+          "type" : "artist",
+          "uri" : "spotify:artist:6DgP9otnZw5z6daOntINxp"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/4EPJlUEBy49EX1wuFOvtjK"
+          },
+          "href" : "https://api.spotify.com/v1/artists/4EPJlUEBy49EX1wuFOvtjK",
+          "id" : "4EPJlUEBy49EX1wuFOvtjK",
+          "name" : "Becky Hill",
+          "type" : "artist",
+          "uri" : "spotify:artist:4EPJlUEBy49EX1wuFOvtjK"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/1R7H7T15beGxVaQQ1MnH78"
+        },
+        "href" : "https://api.spotify.com/v1/albums/1R7H7T15beGxVaQQ1MnH78",
+        "id" : "1R7H7T15beGxVaQQ1MnH78",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b2734db59a9b53658e951f72bd9b",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e024db59a9b53658e951f72bd9b",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d000048514db59a9b53658e951f72bd9b",
+          "width" : 64
+        } ],
+        "name" : "HISTORY",
+        "release_date" : "2022-08-05",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:1R7H7T15beGxVaQQ1MnH78"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/6DgP9otnZw5z6daOntINxp"
+        },
+        "href" : "https://api.spotify.com/v1/artists/6DgP9otnZw5z6daOntINxp",
+        "id" : "6DgP9otnZw5z6daOntINxp",
+        "name" : "Joel Corry",
+        "type" : "artist",
+        "uri" : "spotify:artist:6DgP9otnZw5z6daOntINxp"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/4EPJlUEBy49EX1wuFOvtjK"
+        },
+        "href" : "https://api.spotify.com/v1/artists/4EPJlUEBy49EX1wuFOvtjK",
+        "id" : "4EPJlUEBy49EX1wuFOvtjK",
+        "name" : "Becky Hill",
+        "type" : "artist",
+        "uri" : "spotify:artist:4EPJlUEBy49EX1wuFOvtjK"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 176609,
+      "episode" : false,
+      "explicit" : true,
+      "external_ids" : {
+        "isrc" : "GBAHS2200992"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/5IfHQilcjciOxJQBFCNCCN"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/5IfHQilcjciOxJQBFCNCCN",
+      "id" : "5IfHQilcjciOxJQBFCNCCN",
+      "is_local" : false,
+      "name" : "HISTORY",
+      "popularity" : 78,
+      "preview_url" : "https://p.scdn.co/mp3-preview/a2b7ea0daa733079de6d4f41aa042958f571b89c?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:5IfHQilcjciOxJQBFCNCCN"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-07-08T15:52:58Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/1yxSLGMDHlW21z4YXirZDS"
+          },
+          "href" : "https://api.spotify.com/v1/artists/1yxSLGMDHlW21z4YXirZDS",
+          "id" : "1yxSLGMDHlW21z4YXirZDS",
+          "name" : "Black Eyed Peas",
+          "type" : "artist",
+          "uri" : "spotify:artist:1yxSLGMDHlW21z4YXirZDS"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/0EmeFodog0BfCgMzAIvKQp"
+          },
+          "href" : "https://api.spotify.com/v1/artists/0EmeFodog0BfCgMzAIvKQp",
+          "id" : "0EmeFodog0BfCgMzAIvKQp",
+          "name" : "Shakira",
+          "type" : "artist",
+          "uri" : "spotify:artist:0EmeFodog0BfCgMzAIvKQp"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          "href" : "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+          "id" : "1Cs0zKBU1kc0i8ypK3B9ai",
+          "name" : "David Guetta",
+          "type" : "artist",
+          "uri" : "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+        } ],
+        "available_markets" : [ "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/3plMoBhvQ07H4itII2Qdeb"
+        },
+        "href" : "https://api.spotify.com/v1/albums/3plMoBhvQ07H4itII2Qdeb",
+        "id" : "3plMoBhvQ07H4itII2Qdeb",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b2738576efada2170fafa9577cad",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e028576efada2170fafa9577cad",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d000048518576efada2170fafa9577cad",
+          "width" : 64
+        } ],
+        "name" : "DON'T YOU WORRY",
+        "release_date" : "2022-06-17",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:3plMoBhvQ07H4itII2Qdeb"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/1yxSLGMDHlW21z4YXirZDS"
+        },
+        "href" : "https://api.spotify.com/v1/artists/1yxSLGMDHlW21z4YXirZDS",
+        "id" : "1yxSLGMDHlW21z4YXirZDS",
+        "name" : "Black Eyed Peas",
+        "type" : "artist",
+        "uri" : "spotify:artist:1yxSLGMDHlW21z4YXirZDS"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/0EmeFodog0BfCgMzAIvKQp"
+        },
+        "href" : "https://api.spotify.com/v1/artists/0EmeFodog0BfCgMzAIvKQp",
+        "id" : "0EmeFodog0BfCgMzAIvKQp",
+        "name" : "Shakira",
+        "type" : "artist",
+        "uri" : "spotify:artist:0EmeFodog0BfCgMzAIvKQp"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+        },
+        "href" : "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+        "id" : "1Cs0zKBU1kc0i8ypK3B9ai",
+        "name" : "David Guetta",
+        "type" : "artist",
+        "uri" : "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+      } ],
+      "available_markets" : [ "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 196363,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "USSM12202555"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/0gYXw7aPoybWFfB7btQ0eM"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/0gYXw7aPoybWFfB7btQ0eM",
+      "id" : "0gYXw7aPoybWFfB7btQ0eM",
+      "is_local" : false,
+      "name" : "DON'T YOU WORRY",
+      "popularity" : 85,
+      "preview_url" : "https://p.scdn.co/mp3-preview/5f25edfb6e59438dd172f8d83e43333df9170da7?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:0gYXw7aPoybWFfB7btQ0eM"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-06-24T12:45:24Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/3R6VoMjUANEP9wb7fRNXws"
+          },
+          "href" : "https://api.spotify.com/v1/artists/3R6VoMjUANEP9wb7fRNXws",
+          "id" : "3R6VoMjUANEP9wb7fRNXws",
+          "name" : "Rolf Sanchez",
+          "type" : "artist",
+          "uri" : "spotify:artist:3R6VoMjUANEP9wb7fRNXws"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/2wht4rGcaS39dbSxrvdfEL"
+        },
+        "href" : "https://api.spotify.com/v1/albums/2wht4rGcaS39dbSxrvdfEL",
+        "id" : "2wht4rGcaS39dbSxrvdfEL",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273d0db70853448dcd7a5a19be2",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02d0db70853448dcd7a5a19be2",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851d0db70853448dcd7a5a19be2",
+          "width" : 64
+        } ],
+        "name" : "Darte Un Beso",
+        "release_date" : "2022-05-06",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:2wht4rGcaS39dbSxrvdfEL"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/3R6VoMjUANEP9wb7fRNXws"
+        },
+        "href" : "https://api.spotify.com/v1/artists/3R6VoMjUANEP9wb7fRNXws",
+        "id" : "3R6VoMjUANEP9wb7fRNXws",
+        "name" : "Rolf Sanchez",
+        "type" : "artist",
+        "uri" : "spotify:artist:3R6VoMjUANEP9wb7fRNXws"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 165548,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "NLZ292200049"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/3ZGJTUAhwua3fBi2M9BOUQ"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/3ZGJTUAhwua3fBi2M9BOUQ",
+      "id" : "3ZGJTUAhwua3fBi2M9BOUQ",
+      "is_local" : false,
+      "name" : "Darte Un Beso",
+      "popularity" : 61,
+      "preview_url" : "https://p.scdn.co/mp3-preview/37083df0adbcbd380c74ebbe3aa443d123b4917d?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:3ZGJTUAhwua3fBi2M9BOUQ"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-09-02T17:11:49Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/0YLlTW9rW7ZCy2cA2u3RYk"
+          },
+          "href" : "https://api.spotify.com/v1/artists/0YLlTW9rW7ZCy2cA2u3RYk",
+          "id" : "0YLlTW9rW7ZCy2cA2u3RYk",
+          "name" : "FLEMMING",
+          "type" : "artist",
+          "uri" : "spotify:artist:0YLlTW9rW7ZCy2cA2u3RYk"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/5eir5zFJpES4j7gsymbVyl"
+          },
+          "href" : "https://api.spotify.com/v1/artists/5eir5zFJpES4j7gsymbVyl",
+          "id" : "5eir5zFJpES4j7gsymbVyl",
+          "name" : "Ronnie Flex",
+          "type" : "artist",
+          "uri" : "spotify:artist:5eir5zFJpES4j7gsymbVyl"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/1mAlhigBTplhT8aYBo9tFc"
+        },
+        "href" : "https://api.spotify.com/v1/albums/1mAlhigBTplhT8aYBo9tFc",
+        "id" : "1mAlhigBTplhT8aYBo9tFc",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b2738874439518f54ed6aeb09a66",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e028874439518f54ed6aeb09a66",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d000048518874439518f54ed6aeb09a66",
+          "width" : 64
+        } ],
+        "name" : "Terug Bij Af ft. Ronnie Flex",
+        "release_date" : "2022-08-25",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:1mAlhigBTplhT8aYBo9tFc"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/0YLlTW9rW7ZCy2cA2u3RYk"
+        },
+        "href" : "https://api.spotify.com/v1/artists/0YLlTW9rW7ZCy2cA2u3RYk",
+        "id" : "0YLlTW9rW7ZCy2cA2u3RYk",
+        "name" : "FLEMMING",
+        "type" : "artist",
+        "uri" : "spotify:artist:0YLlTW9rW7ZCy2cA2u3RYk"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/5eir5zFJpES4j7gsymbVyl"
+        },
+        "href" : "https://api.spotify.com/v1/artists/5eir5zFJpES4j7gsymbVyl",
+        "id" : "5eir5zFJpES4j7gsymbVyl",
+        "name" : "Ronnie Flex",
+        "type" : "artist",
+        "uri" : "spotify:artist:5eir5zFJpES4j7gsymbVyl"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 186700,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "NLZ292200122"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/65rDc2X5XZNs9mCvnJyaR1"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/65rDc2X5XZNs9mCvnJyaR1",
+      "id" : "65rDc2X5XZNs9mCvnJyaR1",
+      "is_local" : false,
+      "name" : "Terug Bij Af ft. Ronnie Flex",
+      "popularity" : 66,
+      "preview_url" : "https://p.scdn.co/mp3-preview/a81b4d639898b07482fafdda64613679a76397b7?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:65rDc2X5XZNs9mCvnJyaR1"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-07-24T11:24:45Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/7CajNmpbOovFoOoasH2HaY"
+          },
+          "href" : "https://api.spotify.com/v1/artists/7CajNmpbOovFoOoasH2HaY",
+          "id" : "7CajNmpbOovFoOoasH2HaY",
+          "name" : "Calvin Harris",
+          "type" : "artist",
+          "uri" : "spotify:artist:7CajNmpbOovFoOoasH2HaY"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/31TPClRtHm23RisEBtV3X7"
+          },
+          "href" : "https://api.spotify.com/v1/artists/31TPClRtHm23RisEBtV3X7",
+          "id" : "31TPClRtHm23RisEBtV3X7",
+          "name" : "Justin Timberlake",
+          "type" : "artist",
+          "uri" : "spotify:artist:31TPClRtHm23RisEBtV3X7"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/26VFTg2z8YR0cCuwLzESi2"
+          },
+          "href" : "https://api.spotify.com/v1/artists/26VFTg2z8YR0cCuwLzESi2",
+          "id" : "26VFTg2z8YR0cCuwLzESi2",
+          "name" : "Halsey",
+          "type" : "artist",
+          "uri" : "spotify:artist:26VFTg2z8YR0cCuwLzESi2"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/62SWIKrov7HPXU0Jpc6LY1"
+        },
+        "href" : "https://api.spotify.com/v1/albums/62SWIKrov7HPXU0Jpc6LY1",
+        "id" : "62SWIKrov7HPXU0Jpc6LY1",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b2739b93a80dbfd3d789065d7b67",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e029b93a80dbfd3d789065d7b67",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d000048519b93a80dbfd3d789065d7b67",
+          "width" : 64
+        } ],
+        "name" : "Stay With Me (with Justin Timberlake, Halsey, & Pharrell)",
+        "release_date" : "2022-07-15",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:62SWIKrov7HPXU0Jpc6LY1"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/7CajNmpbOovFoOoasH2HaY"
+        },
+        "href" : "https://api.spotify.com/v1/artists/7CajNmpbOovFoOoasH2HaY",
+        "id" : "7CajNmpbOovFoOoasH2HaY",
+        "name" : "Calvin Harris",
+        "type" : "artist",
+        "uri" : "spotify:artist:7CajNmpbOovFoOoasH2HaY"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/31TPClRtHm23RisEBtV3X7"
+        },
+        "href" : "https://api.spotify.com/v1/artists/31TPClRtHm23RisEBtV3X7",
+        "id" : "31TPClRtHm23RisEBtV3X7",
+        "name" : "Justin Timberlake",
+        "type" : "artist",
+        "uri" : "spotify:artist:31TPClRtHm23RisEBtV3X7"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/26VFTg2z8YR0cCuwLzESi2"
+        },
+        "href" : "https://api.spotify.com/v1/artists/26VFTg2z8YR0cCuwLzESi2",
+        "id" : "26VFTg2z8YR0cCuwLzESi2",
+        "name" : "Halsey",
+        "type" : "artist",
+        "uri" : "spotify:artist:26VFTg2z8YR0cCuwLzESi2"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/2RdwBSPQiwcmiDo9kixcl8"
+        },
+        "href" : "https://api.spotify.com/v1/artists/2RdwBSPQiwcmiDo9kixcl8",
+        "id" : "2RdwBSPQiwcmiDo9kixcl8",
+        "name" : "Pharrell Williams",
+        "type" : "artist",
+        "uri" : "spotify:artist:2RdwBSPQiwcmiDo9kixcl8"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 229282,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "GBARL2201570"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/5lfWrciYtohtIMVDVZd0Rf"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/5lfWrciYtohtIMVDVZd0Rf",
+      "id" : "5lfWrciYtohtIMVDVZd0Rf",
+      "is_local" : false,
+      "name" : "Stay With Me (with Justin Timberlake, Halsey, & Pharrell)",
+      "popularity" : 84,
+      "preview_url" : "https://p.scdn.co/mp3-preview/a7b6c21873ddee1947b2877cff0733b57b0e700d?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:5lfWrciYtohtIMVDVZd0Rf"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-09-09T15:35:55Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/6mS5GeFyhea6w9OKo8PO3p"
+          },
+          "href" : "https://api.spotify.com/v1/artists/6mS5GeFyhea6w9OKo8PO3p",
+          "id" : "6mS5GeFyhea6w9OKo8PO3p",
+          "name" : "Goldband",
+          "type" : "artist",
+          "uri" : "spotify:artist:6mS5GeFyhea6w9OKo8PO3p"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/55hLMMakne8TwUe39HmDZ1"
+        },
+        "href" : "https://api.spotify.com/v1/albums/55hLMMakne8TwUe39HmDZ1",
+        "id" : "55hLMMakne8TwUe39HmDZ1",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273282673c5df7a66ae5710e4a9",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02282673c5df7a66ae5710e4a9",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851282673c5df7a66ae5710e4a9",
+          "width" : 64
+        } ],
+        "name" : "Noodgeval",
+        "release_date" : "2021-07-09",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:55hLMMakne8TwUe39HmDZ1"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/6mS5GeFyhea6w9OKo8PO3p"
+        },
+        "href" : "https://api.spotify.com/v1/artists/6mS5GeFyhea6w9OKo8PO3p",
+        "id" : "6mS5GeFyhea6w9OKo8PO3p",
+        "name" : "Goldband",
+        "type" : "artist",
+        "uri" : "spotify:artist:6mS5GeFyhea6w9OKo8PO3p"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 214383,
+      "episode" : false,
+      "explicit" : true,
+      "external_ids" : {
+        "isrc" : "NLSB72100302"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/27NXXRJAv6Oa8WdtAbhrTR"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/27NXXRJAv6Oa8WdtAbhrTR",
+      "id" : "27NXXRJAv6Oa8WdtAbhrTR",
+      "is_local" : false,
+      "name" : "Noodgeval",
+      "popularity" : 50,
+      "preview_url" : "https://p.scdn.co/mp3-preview/fad2bcfd59f7b7a008017f8fd7886bef1ef71df2?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:27NXXRJAv6Oa8WdtAbhrTR"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-08-26T15:59:17Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/44IF5iKnm06JFziiLsHpyJ"
+          },
+          "href" : "https://api.spotify.com/v1/artists/44IF5iKnm06JFziiLsHpyJ",
+          "id" : "44IF5iKnm06JFziiLsHpyJ",
+          "name" : "QUIQUE",
+          "type" : "artist",
+          "uri" : "spotify:artist:44IF5iKnm06JFziiLsHpyJ"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "FI", "FJ", "FM", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/4Aki0Qb1ior78C1RcWb5oX"
+        },
+        "href" : "https://api.spotify.com/v1/albums/4Aki0Qb1ior78C1RcWb5oX",
+        "id" : "4Aki0Qb1ior78C1RcWb5oX",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273f2e4b6550d664c5e9a139320",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02f2e4b6550d664c5e9a139320",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851f2e4b6550d664c5e9a139320",
+          "width" : 64
+        } ],
+        "name" : "Camino",
+        "release_date" : "2022-08-05",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:4Aki0Qb1ior78C1RcWb5oX"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/44IF5iKnm06JFziiLsHpyJ"
+        },
+        "href" : "https://api.spotify.com/v1/artists/44IF5iKnm06JFziiLsHpyJ",
+        "id" : "44IF5iKnm06JFziiLsHpyJ",
+        "name" : "QUIQUE",
+        "type" : "artist",
+        "uri" : "spotify:artist:44IF5iKnm06JFziiLsHpyJ"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "FI", "FJ", "FM", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 176915,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "NLZ292200117"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/50UWMLI07e82G1VLMZ2M11"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/50UWMLI07e82G1VLMZ2M11",
+      "id" : "50UWMLI07e82G1VLMZ2M11",
+      "is_local" : false,
+      "name" : "Camino",
+      "popularity" : 61,
+      "preview_url" : "https://p.scdn.co/mp3-preview/b306d8cc45c8c15a39c705df1688554faec79ab4?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:50UWMLI07e82G1VLMZ2M11"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-08-26T15:59:24Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/7qmpXeNz2ojlMl2EEfkeLs"
+          },
+          "href" : "https://api.spotify.com/v1/artists/7qmpXeNz2ojlMl2EEfkeLs",
+          "id" : "7qmpXeNz2ojlMl2EEfkeLs",
+          "name" : "Nicky Youre",
+          "type" : "artist",
+          "uri" : "spotify:artist:7qmpXeNz2ojlMl2EEfkeLs"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/38PzLQE4GW8o7A18oGhi0x"
+          },
+          "href" : "https://api.spotify.com/v1/artists/38PzLQE4GW8o7A18oGhi0x",
+          "id" : "38PzLQE4GW8o7A18oGhi0x",
+          "name" : "dazy",
+          "type" : "artist",
+          "uri" : "spotify:artist:38PzLQE4GW8o7A18oGhi0x"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/0VaHnwzDug4AcDkejYDUl5"
+        },
+        "href" : "https://api.spotify.com/v1/albums/0VaHnwzDug4AcDkejYDUl5",
+        "id" : "0VaHnwzDug4AcDkejYDUl5",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b2730ed2184bf3fb4466d623a874",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e020ed2184bf3fb4466d623a874",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d000048510ed2184bf3fb4466d623a874",
+          "width" : 64
+        } ],
+        "name" : "Sunroof",
+        "release_date" : "2021-12-03",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:0VaHnwzDug4AcDkejYDUl5"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/7qmpXeNz2ojlMl2EEfkeLs"
+        },
+        "href" : "https://api.spotify.com/v1/artists/7qmpXeNz2ojlMl2EEfkeLs",
+        "id" : "7qmpXeNz2ojlMl2EEfkeLs",
+        "name" : "Nicky Youre",
+        "type" : "artist",
+        "uri" : "spotify:artist:7qmpXeNz2ojlMl2EEfkeLs"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/38PzLQE4GW8o7A18oGhi0x"
+        },
+        "href" : "https://api.spotify.com/v1/artists/38PzLQE4GW8o7A18oGhi0x",
+        "id" : "38PzLQE4GW8o7A18oGhi0x",
+        "name" : "dazy",
+        "type" : "artist",
+        "uri" : "spotify:artist:38PzLQE4GW8o7A18oGhi0x"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 163025,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "USQX92202129"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/4h4QlmocP3IuwYEj2j14p8"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/4h4QlmocP3IuwYEj2j14p8",
+      "id" : "4h4QlmocP3IuwYEj2j14p8",
+      "is_local" : false,
+      "name" : "Sunroof",
+      "popularity" : 92,
+      "preview_url" : "https://p.scdn.co/mp3-preview/7c8b08cc640f6065a2daaf7d92ee49a640d8c4b8?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:4h4QlmocP3IuwYEj2j14p8"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-07-01T14:51:11Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/53XhwfbYqKCa1cC15pYq2q"
+          },
+          "href" : "https://api.spotify.com/v1/artists/53XhwfbYqKCa1cC15pYq2q",
+          "id" : "53XhwfbYqKCa1cC15pYq2q",
+          "name" : "Imagine Dragons",
+          "type" : "artist",
+          "uri" : "spotify:artist:53XhwfbYqKCa1cC15pYq2q"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/587Ykd8NOCdzRmaW4nlT4e"
+        },
+        "href" : "https://api.spotify.com/v1/albums/587Ykd8NOCdzRmaW4nlT4e",
+        "id" : "587Ykd8NOCdzRmaW4nlT4e",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b2733ae51d6dc9ed5ffcf9988639",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e023ae51d6dc9ed5ffcf9988639",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d000048513ae51d6dc9ed5ffcf9988639",
+          "width" : 64
+        } ],
+        "name" : "Sharks",
+        "release_date" : "2022-06-24",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:587Ykd8NOCdzRmaW4nlT4e"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/53XhwfbYqKCa1cC15pYq2q"
+        },
+        "href" : "https://api.spotify.com/v1/artists/53XhwfbYqKCa1cC15pYq2q",
+        "id" : "53XhwfbYqKCa1cC15pYq2q",
+        "name" : "Imagine Dragons",
+        "type" : "artist",
+        "uri" : "spotify:artist:53XhwfbYqKCa1cC15pYq2q"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 190883,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "USUM72205464"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/0TyUOnU4H4GLqOcrH0auc8"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/0TyUOnU4H4GLqOcrH0auc8",
+      "id" : "0TyUOnU4H4GLqOcrH0auc8",
+      "is_local" : false,
+      "name" : "Sharks",
+      "popularity" : 82,
+      "preview_url" : "https://p.scdn.co/mp3-preview/40d40ba62c2ed9f26f5c70fc68e72c6906a38879?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:0TyUOnU4H4GLqOcrH0auc8"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-09-09T15:36:02Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/0u6GtibW46tFX7koQ6uNJZ"
+          },
+          "href" : "https://api.spotify.com/v1/artists/0u6GtibW46tFX7koQ6uNJZ",
+          "id" : "0u6GtibW46tFX7koQ6uNJZ",
+          "name" : "Topic",
+          "type" : "artist",
+          "uri" : "spotify:artist:0u6GtibW46tFX7koQ6uNJZ"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/5Wg2b4Mp42gicxEeDNawf7"
+          },
+          "href" : "https://api.spotify.com/v1/artists/5Wg2b4Mp42gicxEeDNawf7",
+          "id" : "5Wg2b4Mp42gicxEeDNawf7",
+          "name" : "A7S",
+          "type" : "artist",
+          "uri" : "spotify:artist:5Wg2b4Mp42gicxEeDNawf7"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/2NIChqkijGw4r4Dqfmg0A3"
+        },
+        "href" : "https://api.spotify.com/v1/albums/2NIChqkijGw4r4Dqfmg0A3",
+        "id" : "2NIChqkijGw4r4Dqfmg0A3",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273e1cafe604179a9438dee7a94",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02e1cafe604179a9438dee7a94",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851e1cafe604179a9438dee7a94",
+          "width" : 64
+        } ],
+        "name" : "Kernkraft 400 (A Better Day)",
+        "release_date" : "2022-06-17",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:2NIChqkijGw4r4Dqfmg0A3"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/0u6GtibW46tFX7koQ6uNJZ"
+        },
+        "href" : "https://api.spotify.com/v1/artists/0u6GtibW46tFX7koQ6uNJZ",
+        "id" : "0u6GtibW46tFX7koQ6uNJZ",
+        "name" : "Topic",
+        "type" : "artist",
+        "uri" : "spotify:artist:0u6GtibW46tFX7koQ6uNJZ"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/5Wg2b4Mp42gicxEeDNawf7"
+        },
+        "href" : "https://api.spotify.com/v1/artists/5Wg2b4Mp42gicxEeDNawf7",
+        "id" : "5Wg2b4Mp42gicxEeDNawf7",
+        "name" : "A7S",
+        "type" : "artist",
+        "uri" : "spotify:artist:5Wg2b4Mp42gicxEeDNawf7"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 165800,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "DECE72201091"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/3kcKlOkQQEPVwxwljbGJ5p"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/3kcKlOkQQEPVwxwljbGJ5p",
+      "id" : "3kcKlOkQQEPVwxwljbGJ5p",
+      "is_local" : false,
+      "name" : "Kernkraft 400 (A Better Day)",
+      "popularity" : 78,
+      "preview_url" : "https://p.scdn.co/mp3-preview/eda81ed5589c73173100f27b3b4d830e9973bc95?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:3kcKlOkQQEPVwxwljbGJ5p"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-09-02T17:11:55Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "album",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/4gzpq5DPGxSnKTe4SA8HAU"
+          },
+          "href" : "https://api.spotify.com/v1/artists/4gzpq5DPGxSnKTe4SA8HAU",
+          "id" : "4gzpq5DPGxSnKTe4SA8HAU",
+          "name" : "Coldplay",
+          "type" : "artist",
+          "uri" : "spotify:artist:4gzpq5DPGxSnKTe4SA8HAU"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/06mXfvDsRZNfnsGZvX2zpb"
+        },
+        "href" : "https://api.spotify.com/v1/albums/06mXfvDsRZNfnsGZvX2zpb",
+        "id" : "06mXfvDsRZNfnsGZvX2zpb",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b273ec10f247b100da1ce0d80b6d",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e02ec10f247b100da1ce0d80b6d",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d00004851ec10f247b100da1ce0d80b6d",
+          "width" : 64
+        } ],
+        "name" : "Music Of The Spheres",
+        "release_date" : "2021-10-15",
+        "release_date_precision" : "day",
+        "total_tracks" : 12,
+        "type" : "album",
+        "uri" : "spotify:album:06mXfvDsRZNfnsGZvX2zpb"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/4gzpq5DPGxSnKTe4SA8HAU"
+        },
+        "href" : "https://api.spotify.com/v1/artists/4gzpq5DPGxSnKTe4SA8HAU",
+        "id" : "4gzpq5DPGxSnKTe4SA8HAU",
+        "name" : "Coldplay",
+        "type" : "artist",
+        "uri" : "spotify:artist:4gzpq5DPGxSnKTe4SA8HAU"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AT", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CH", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GB", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 266704,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "GBAYE2100945"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/23BO6YozrAXUta1buxFZ80"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/23BO6YozrAXUta1buxFZ80",
+      "id" : "23BO6YozrAXUta1buxFZ80",
+      "is_local" : false,
+      "name" : "Humankind",
+      "popularity" : 68,
+      "preview_url" : "https://p.scdn.co/mp3-preview/58a7f9ad969a55df082f01009f408a884540c236?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 3,
+      "type" : "track",
+      "uri" : "spotify:track:23BO6YozrAXUta1buxFZ80"
+    },
+    "video_thumbnail" : {
+      "url" : null
+    }
+  }, {
+    "added_at" : "2022-08-05T15:28:03Z",
+    "added_by" : {
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "is_local" : false,
+    "primary_color" : null,
+    "track" : {
+      "album" : {
+        "album_type" : "single",
+        "artists" : [ {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/2HkAI0YrEcgoR8QdaURqhO"
+          },
+          "href" : "https://api.spotify.com/v1/artists/2HkAI0YrEcgoR8QdaURqhO",
+          "id" : "2HkAI0YrEcgoR8QdaURqhO",
+          "name" : "Dimitri Vegas",
+          "type" : "artist",
+          "uri" : "spotify:artist:2HkAI0YrEcgoR8QdaURqhO"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+          },
+          "href" : "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+          "id" : "1Cs0zKBU1kc0i8ypK3B9ai",
+          "name" : "David Guetta",
+          "type" : "artist",
+          "uri" : "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+        }, {
+          "external_urls" : {
+            "spotify" : "https://open.spotify.com/artist/40xbWSB4JPdOkRyuTDy1oP"
+          },
+          "href" : "https://api.spotify.com/v1/artists/40xbWSB4JPdOkRyuTDy1oP",
+          "id" : "40xbWSB4JPdOkRyuTDy1oP",
+          "name" : "Nicole Scherzinger",
+          "type" : "artist",
+          "uri" : "spotify:artist:40xbWSB4JPdOkRyuTDy1oP"
+        } ],
+        "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/album/3R69AWht6e2vZq7Cg3XGPH"
+        },
+        "href" : "https://api.spotify.com/v1/albums/3R69AWht6e2vZq7Cg3XGPH",
+        "id" : "3R69AWht6e2vZq7Cg3XGPH",
+        "images" : [ {
+          "height" : 640,
+          "url" : "https://i.scdn.co/image/ab67616d0000b27388155ffba44b9a2145a8c6f6",
+          "width" : 640
+        }, {
+          "height" : 300,
+          "url" : "https://i.scdn.co/image/ab67616d00001e0288155ffba44b9a2145a8c6f6",
+          "width" : 300
+        }, {
+          "height" : 64,
+          "url" : "https://i.scdn.co/image/ab67616d0000485188155ffba44b9a2145a8c6f6",
+          "width" : 64
+        } ],
+        "name" : "The Drop",
+        "release_date" : "2022-06-24",
+        "release_date_precision" : "day",
+        "total_tracks" : 1,
+        "type" : "album",
+        "uri" : "spotify:album:3R69AWht6e2vZq7Cg3XGPH"
+      },
+      "artists" : [ {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/2HkAI0YrEcgoR8QdaURqhO"
+        },
+        "href" : "https://api.spotify.com/v1/artists/2HkAI0YrEcgoR8QdaURqhO",
+        "id" : "2HkAI0YrEcgoR8QdaURqhO",
+        "name" : "Dimitri Vegas",
+        "type" : "artist",
+        "uri" : "spotify:artist:2HkAI0YrEcgoR8QdaURqhO"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/1Cs0zKBU1kc0i8ypK3B9ai"
+        },
+        "href" : "https://api.spotify.com/v1/artists/1Cs0zKBU1kc0i8ypK3B9ai",
+        "id" : "1Cs0zKBU1kc0i8ypK3B9ai",
+        "name" : "David Guetta",
+        "type" : "artist",
+        "uri" : "spotify:artist:1Cs0zKBU1kc0i8ypK3B9ai"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/40xbWSB4JPdOkRyuTDy1oP"
+        },
+        "href" : "https://api.spotify.com/v1/artists/40xbWSB4JPdOkRyuTDy1oP",
+        "id" : "40xbWSB4JPdOkRyuTDy1oP",
+        "name" : "Nicole Scherzinger",
+        "type" : "artist",
+        "uri" : "spotify:artist:40xbWSB4JPdOkRyuTDy1oP"
+      }, {
+        "external_urls" : {
+          "spotify" : "https://open.spotify.com/artist/13NpuESz6tlK819yBs0PuS"
+        },
+        "href" : "https://api.spotify.com/v1/artists/13NpuESz6tlK819yBs0PuS",
+        "id" : "13NpuESz6tlK819yBs0PuS",
+        "name" : "Azteck",
+        "type" : "artist",
+        "uri" : "spotify:artist:13NpuESz6tlK819yBs0PuS"
+      } ],
+      "available_markets" : [ "AD", "AE", "AG", "AL", "AM", "AO", "AR", "AU", "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BN", "BO", "BR", "BS", "BT", "BW", "BY", "BZ", "CA", "CD", "CG", "CI", "CL", "CM", "CO", "CR", "CV", "CW", "CY", "CZ", "DJ", "DK", "DM", "DO", "DZ", "EC", "EE", "EG", "ES", "FI", "FJ", "FM", "FR", "GA", "GD", "GE", "GH", "GM", "GN", "GQ", "GR", "GT", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IL", "IN", "IQ", "IS", "IT", "JM", "JO", "KE", "KG", "KH", "KI", "KM", "KN", "KR", "KW", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU", "LV", "LY", "MA", "MC", "MD", "ME", "MG", "MH", "MK", "ML", "MN", "MO", "MR", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NE", "NG", "NI", "NL", "NO", "NP", "NR", "NZ", "OM", "PA", "PE", "PG", "PH", "PK", "PL", "PS", "PT", "PW", "PY", "QA", "RO", "RS", "RW", "SA", "SB", "SC", "SE", "SG", "SI", "SK", "SL", "SM", "SN", "SR", "ST", "SV", "SZ", "TD", "TG", "TH", "TJ", "TL", "TN", "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VC", "VE", "VN", "VU", "WS", "XK", "ZA", "ZM", "ZW" ],
+      "disc_number" : 1,
+      "duration_ms" : 121987,
+      "episode" : false,
+      "explicit" : false,
+      "external_ids" : {
+        "isrc" : "BEIW12200306"
+      },
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/track/013PVeWEFQio3XHFH9rIC6"
+      },
+      "href" : "https://api.spotify.com/v1/tracks/013PVeWEFQio3XHFH9rIC6",
+      "id" : "013PVeWEFQio3XHFH9rIC6",
+      "is_local" : false,
+      "name" : "The Drop",
+      "popularity" : 72,
+      "preview_url" : "https://p.scdn.co/mp3-preview/105192f9ab21357f6b9fe2f98f5e51970e37efcd?cid=774b29d4f13844c495f206cafdad9c86",
+      "track" : true,
+      "track_number" : 1,
+      "type" : "track",
+      "uri" : "spotify:track:013PVeWEFQio3XHFH9rIC6"
+    },
+    "video_thumbnail" : {
+      "url" : null
     }
   } ],
-  "limit" : 2,
-  "next" : "https://api.spotify.com/v1/users/spotify_espa%C3%B1a/playlists/21THa8j9TaSGuXYNBU5tsC/tracks?offset=2&limit=2",
+  "limit" : 100,
+  "next" : null,
   "offset" : 0,
   "previous" : null,
-  "total" : 47
+  "total" : 40
 }

--- a/test_data/playlists_for_user.txt
+++ b/test_data/playlists_for_user.txt
@@ -2,119 +2,239 @@
   "href" : "https://api.spotify.com/v1/users/whizler/playlists?offset=0&limit=20",
   "items" : [ {
     "collaborative" : false,
+    "description" : "Nederlandse Top 40, de enige echte hitlijst van Nederland! Official Dutch Top 40. Check top40.nl voor alle details en luister iedere vrijdag vanaf 14.00 uur naar de lijst op Qmusic met Domien Verschuuren.",
     "external_urls" : {
-      "spotify" : "http://open.spotify.com/user/nederlandse_top_40/playlist/7vrhBxI0VHV0CNcj06Cno3"
+      "spotify" : "https://open.spotify.com/playlist/5lH9NjOeJvctAO92ZrKQNB"
     },
-    "href" : "https://api.spotify.com/v1/users/nederlandse_top_40/playlists/7vrhBxI0VHV0CNcj06Cno3",
-    "id" : "7vrhBxI0VHV0CNcj06Cno3",
+    "href" : "https://api.spotify.com/v1/playlists/5lH9NjOeJvctAO92ZrKQNB",
+    "id" : "5lH9NjOeJvctAO92ZrKQNB",
     "images" : [ {
-      "height" : 640,
-      "url" : "https://mosaic.scdn.co/640/ee915e50041ce0dd1dfde71cc6e2c28e078aa8e83dac748919303efb1a48a6c5994307f54a9fff8ecfa5aa42c03d94a58e35e842da62ae7ebf30d53dda803660b1bb9226871fe5d127c49a70cbbc6bd1",
-      "width" : 640
-    }, {
-      "height" : 300,
-      "url" : "https://mosaic.scdn.co/300/ee915e50041ce0dd1dfde71cc6e2c28e078aa8e83dac748919303efb1a48a6c5994307f54a9fff8ecfa5aa42c03d94a58e35e842da62ae7ebf30d53dda803660b1bb9226871fe5d127c49a70cbbc6bd1",
-      "width" : 300
-    }, {
-      "height" : 60,
-      "url" : "https://mosaic.scdn.co/60/ee915e50041ce0dd1dfde71cc6e2c28e078aa8e83dac748919303efb1a48a6c5994307f54a9fff8ecfa5aa42c03d94a58e35e842da62ae7ebf30d53dda803660b1bb9226871fe5d127c49a70cbbc6bd1",
-      "width" : 60
+      "height" : null,
+      "url" : "https://i.scdn.co/image/ab67706c0000bebb028a62a3c0cac03d75d26f02",
+      "width" : null
     } ],
-    "name" : "Nederlandse Tipparade",
+    "name" : "Top 40",
     "owner" : {
+      "display_name" : "Nederlandse Top 40",
       "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/nederlandse_top_40"
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
       },
       "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
       "id" : "nederlandse_top_40",
       "type" : "user",
       "uri" : "spotify:user:nederlandse_top_40"
     },
+    "primary_color" : null,
     "public" : true,
+    "snapshot_id" : "MTM1MDMsNThlNjY3ZmM0OGQxNDM1MzE3OGY1NDk4NmQyNTMzNDczOGFlZWI2Yg==",
     "tracks" : {
-      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40/playlists/7vrhBxI0VHV0CNcj06Cno3/tracks",
-      "total" : 29
-    },
-    "type" : "playlist",
-    "uri" : "spotify:user:nederlandse_top_40:playlist:7vrhBxI0VHV0CNcj06Cno3"
-  }, {
-    "collaborative" : false,
-    "external_urls" : {
-      "spotify" : "http://open.spotify.com/user/1133215025/playlist/6yLFV3fDchwcGliaqYlp6T"
-    },
-    "href" : "https://api.spotify.com/v1/users/1133215025/playlists/6yLFV3fDchwcGliaqYlp6T",
-    "id" : "6yLFV3fDchwcGliaqYlp6T",
-    "images" : [ {
-      "height" : 640,
-      "url" : "https://mosaic.scdn.co/640/0fc4f5402a0a8dc60df091054b61010bdf2618ecf3cf87bfde0748d389702a69e0ba01f6091e24032288494ae80940bed4f31bfb1c6e9bec0f0729a8a8d38a3b1fcedf019957a93b8982fc1a54977aba",
-      "width" : 640
-    }, {
-      "height" : 300,
-      "url" : "https://mosaic.scdn.co/300/0fc4f5402a0a8dc60df091054b61010bdf2618ecf3cf87bfde0748d389702a69e0ba01f6091e24032288494ae80940bed4f31bfb1c6e9bec0f0729a8a8d38a3b1fcedf019957a93b8982fc1a54977aba",
-      "width" : 300
-    }, {
-      "height" : 60,
-      "url" : "https://mosaic.scdn.co/60/0fc4f5402a0a8dc60df091054b61010bdf2618ecf3cf87bfde0748d389702a69e0ba01f6091e24032288494ae80940bed4f31bfb1c6e9bec0f0729a8a8d38a3b1fcedf019957a93b8982fc1a54977aba",
-      "width" : 60
-    } ],
-    "name" : "NL Totaallijst (Mega top 50 - Top 40 - Tipparade - 3fm playlist - Supercrazyturbotophit)",
-    "owner" : {
-      "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/1133215025"
-      },
-      "href" : "https://api.spotify.com/v1/users/1133215025",
-      "id" : "1133215025",
-      "type" : "user",
-      "uri" : "spotify:user:1133215025"
-    },
-    "public" : true,
-    "tracks" : {
-      "href" : "https://api.spotify.com/v1/users/1133215025/playlists/6yLFV3fDchwcGliaqYlp6T/tracks",
-      "total" : 97
-    },
-    "type" : "playlist",
-    "uri" : "spotify:user:1133215025:playlist:6yLFV3fDchwcGliaqYlp6T"
-  }, {
-    "collaborative" : false,
-    "external_urls" : {
-      "spotify" : "http://open.spotify.com/user/vincsie/playlist/1jM0LrhiTpxx9NtrJYRi28"
-    },
-    "href" : "https://api.spotify.com/v1/users/vincsie/playlists/1jM0LrhiTpxx9NtrJYRi28",
-    "id" : "1jM0LrhiTpxx9NtrJYRi28",
-    "images" : [ {
-      "height" : 640,
-      "url" : "https://mosaic.scdn.co/640/646e9619750dfa3d1eadbbea959dc6f528a9109e4956daa8f52ba99d2a2a5818bdec2d05b3c4e4f6080e781821d768e4ba130a3645f7a4367fe8abcb70d6105c78c0dcb66d4a762dd1272473578ef9d7",
-      "width" : 640
-    }, {
-      "height" : 300,
-      "url" : "https://mosaic.scdn.co/300/646e9619750dfa3d1eadbbea959dc6f528a9109e4956daa8f52ba99d2a2a5818bdec2d05b3c4e4f6080e781821d768e4ba130a3645f7a4367fe8abcb70d6105c78c0dcb66d4a762dd1272473578ef9d7",
-      "width" : 300
-    }, {
-      "height" : 60,
-      "url" : "https://mosaic.scdn.co/60/646e9619750dfa3d1eadbbea959dc6f528a9109e4956daa8f52ba99d2a2a5818bdec2d05b3c4e4f6080e781821d768e4ba130a3645f7a4367fe8abcb70d6105c78c0dcb66d4a762dd1272473578ef9d7",
-      "width" : 60
-    } ],
-    "name" : "Top 40 nl / www.HotSpotify.com",
-    "owner" : {
-      "external_urls" : {
-        "spotify" : "http://open.spotify.com/user/vincsie"
-      },
-      "href" : "https://api.spotify.com/v1/users/vincsie",
-      "id" : "vincsie",
-      "type" : "user",
-      "uri" : "spotify:user:vincsie"
-    },
-    "public" : true,
-    "tracks" : {
-      "href" : "https://api.spotify.com/v1/users/vincsie/playlists/1jM0LrhiTpxx9NtrJYRi28/tracks",
+      "href" : "https://api.spotify.com/v1/playlists/5lH9NjOeJvctAO92ZrKQNB/tracks",
       "total" : 40
     },
     "type" : "playlist",
-    "uri" : "spotify:user:vincsie:playlist:1jM0LrhiTpxx9NtrJYRi28"
+    "uri" : "spotify:playlist:5lH9NjOeJvctAO92ZrKQNB"
+  }, {
+    "collaborative" : false,
+    "description" : "Hits to boost your mood and fill you with happiness!",
+    "external_urls" : {
+      "spotify" : "https://open.spotify.com/playlist/37i9dQZF1DXdPec7aLTmlC"
+    },
+    "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DXdPec7aLTmlC",
+    "id" : "37i9dQZF1DXdPec7aLTmlC",
+    "images" : [ {
+      "height" : null,
+      "url" : "https://i.scdn.co/image/ab67706f00000003b55b6074da1d43715fc16d6d",
+      "width" : null
+    } ],
+    "name" : "Happy Hits!",
+    "owner" : {
+      "display_name" : "Spotify",
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/spotify"
+      },
+      "href" : "https://api.spotify.com/v1/users/spotify",
+      "id" : "spotify",
+      "type" : "user",
+      "uri" : "spotify:user:spotify"
+    },
+    "primary_color" : null,
+    "public" : true,
+    "snapshot_id" : "MTY2MzI3OTI2MCwwMDAwMDAwMDg2MTBkOGJjODI0ZTRkM2ExOGZhMDQ5ZjhhZjgyMTFh",
+    "tracks" : {
+      "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DXdPec7aLTmlC/tracks",
+      "total" : 100
+    },
+    "type" : "playlist",
+    "uri" : "spotify:playlist:37i9dQZF1DXdPec7aLTmlC"
+  }, {
+    "collaborative" : false,
+    "description" : "Check deze 'Feel good' soundtrack voor een goed humeur!!",
+    "external_urls" : {
+      "spotify" : "https://open.spotify.com/playlist/37i9dQZF1DWWeNODNe68OF"
+    },
+    "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DWWeNODNe68OF",
+    "id" : "37i9dQZF1DWWeNODNe68OF",
+    "images" : [ {
+      "height" : null,
+      "url" : "https://i.scdn.co/image/ab67706f000000036aca34d6f22bdf3c88b9733f",
+      "width" : null
+    } ],
+    "name" : "Feeling Good, Feeling Great",
+    "owner" : {
+      "display_name" : "Spotify",
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/spotify"
+      },
+      "href" : "https://api.spotify.com/v1/users/spotify",
+      "id" : "spotify",
+      "type" : "user",
+      "uri" : "spotify:user:spotify"
+    },
+    "primary_color" : null,
+    "public" : true,
+    "snapshot_id" : "MTY2MzI2NDczOSwwMDAwMDAwMGZjZDJjNjBjNTY4NjI0NDNlNWZiYzhlOGY1NjQ0NTUw",
+    "tracks" : {
+      "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DWWeNODNe68OF/tracks",
+      "total" : 100
+    },
+    "type" : "playlist",
+    "uri" : "spotify:playlist:37i9dQZF1DWWeNODNe68OF"
+  }, {
+    "collaborative" : false,
+    "description" : "Lekker rustig aan doen op zondag met deze zachte pop liedjes.",
+    "external_urls" : {
+      "spotify" : "https://open.spotify.com/playlist/37i9dQZF1DWZpGSuzrdTXg"
+    },
+    "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DWZpGSuzrdTXg",
+    "id" : "37i9dQZF1DWZpGSuzrdTXg",
+    "images" : [ {
+      "height" : null,
+      "url" : "https://i.scdn.co/image/ab67706f000000035dff4961b72d9f7b52095550",
+      "width" : null
+    } ],
+    "name" : "Easy On Sunday",
+    "owner" : {
+      "display_name" : "Spotify",
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/spotify"
+      },
+      "href" : "https://api.spotify.com/v1/users/spotify",
+      "id" : "spotify",
+      "type" : "user",
+      "uri" : "spotify:user:spotify"
+    },
+    "primary_color" : null,
+    "public" : true,
+    "snapshot_id" : "MTY2Mjc1NDQ5OCwwMDAwMDAwMDNmNDdiZjY0MGM4YzI1Y2ZkZmRkZGEzNzk1ZTYxOTlk",
+    "tracks" : {
+      "href" : "https://api.spotify.com/v1/playlists/37i9dQZF1DWZpGSuzrdTXg/tracks",
+      "total" : 100
+    },
+    "type" : "playlist",
+    "uri" : "spotify:playlist:37i9dQZF1DWZpGSuzrdTXg"
+  }, {
+    "collaborative" : false,
+    "description" : "Einfach auf und davon und den Gedanken freien Lauf lassen.",
+    "external_urls" : {
+      "spotify" : "https://open.spotify.com/playlist/18V3GF4nC6II1tqwo4Sa5k"
+    },
+    "href" : "https://api.spotify.com/v1/playlists/18V3GF4nC6II1tqwo4Sa5k",
+    "id" : "18V3GF4nC6II1tqwo4Sa5k",
+    "images" : [ {
+      "height" : null,
+      "url" : "https://i.scdn.co/image/ab67706c0000bebbb21e9030332ae96236dd70e6",
+      "width" : null
+    } ],
+    "name" : "Roadtrip",
+    "owner" : {
+      "display_name" : "Spotify Deutschland",
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/spotify_germany"
+      },
+      "href" : "https://api.spotify.com/v1/users/spotify_germany",
+      "id" : "spotify_germany",
+      "type" : "user",
+      "uri" : "spotify:user:spotify_germany"
+    },
+    "primary_color" : null,
+    "public" : true,
+    "snapshot_id" : "MzEsOGI2NjA5YWUzNzI1MjZlNjVmYTM2YzZkYTQ1NWJlZThiNTBlZDVmNg==",
+    "tracks" : {
+      "href" : "https://api.spotify.com/v1/playlists/18V3GF4nC6II1tqwo4Sa5k/tracks",
+      "total" : 53
+    },
+    "type" : "playlist",
+    "uri" : "spotify:playlist:18V3GF4nC6II1tqwo4Sa5k"
+  }, {
+    "collaborative" : false,
+    "description" : "Hier vind je alle nieuwe tracks die je op 3FM regelmatig voorbij hoort komen. Iedere vrijdag update!",
+    "external_urls" : {
+      "spotify" : "https://open.spotify.com/playlist/1yzak2pFIMsjWQRD38Hstf"
+    },
+    "href" : "https://api.spotify.com/v1/playlists/1yzak2pFIMsjWQRD38Hstf",
+    "id" : "1yzak2pFIMsjWQRD38Hstf",
+    "images" : [ {
+      "height" : null,
+      "url" : "https://i.scdn.co/image/ab67706c0000bebbc3fcaf0fce84bd8080ab8363",
+      "width" : null
+    } ],
+    "name" : "3FM 📻 Now Playing",
+    "owner" : {
+      "display_name" : "3FM",
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/3fm"
+      },
+      "href" : "https://api.spotify.com/v1/users/3fm",
+      "id" : "3fm",
+      "type" : "user",
+      "uri" : "spotify:user:3fm"
+    },
+    "primary_color" : null,
+    "public" : true,
+    "snapshot_id" : "NDM3OCw0ZDhiNWRmZDNjNjc4Y2E0Y2Q1MzRmYzMxMzdkOTZiNTk2NWJmZTlk",
+    "tracks" : {
+      "href" : "https://api.spotify.com/v1/playlists/1yzak2pFIMsjWQRD38Hstf/tracks",
+      "total" : 50
+    },
+    "type" : "playlist",
+    "uri" : "spotify:playlist:1yzak2pFIMsjWQRD38Hstf"
+  }, {
+    "collaborative" : false,
+    "description" : "Iedere week staan de kanshebbers voor een notering in de  Top 40 genoteerd in de Tipparade.",
+    "external_urls" : {
+      "spotify" : "https://open.spotify.com/playlist/7vrhBxI0VHV0CNcj06Cno3"
+    },
+    "href" : "https://api.spotify.com/v1/playlists/7vrhBxI0VHV0CNcj06Cno3",
+    "id" : "7vrhBxI0VHV0CNcj06Cno3",
+    "images" : [ {
+      "height" : null,
+      "url" : "https://i.scdn.co/image/ab67706c0000bebbd40955c24082a10e09f7847c",
+      "width" : null
+    } ],
+    "name" : "Tipparade",
+    "owner" : {
+      "display_name" : "Nederlandse Top 40",
+      "external_urls" : {
+        "spotify" : "https://open.spotify.com/user/nederlandse_top_40"
+      },
+      "href" : "https://api.spotify.com/v1/users/nederlandse_top_40",
+      "id" : "nederlandse_top_40",
+      "type" : "user",
+      "uri" : "spotify:user:nederlandse_top_40"
+    },
+    "primary_color" : null,
+    "public" : true,
+    "snapshot_id" : "MTMwMDAsZjJmOTNiZDc5ZWQ1ZjhjZTQwNjZhZDQzOTFjZGZiMjQ4M2Q1MWM4Ng==",
+    "tracks" : {
+      "href" : "https://api.spotify.com/v1/playlists/7vrhBxI0VHV0CNcj06Cno3/tracks",
+      "total" : 30
+    },
+    "type" : "playlist",
+    "uri" : "spotify:playlist:7vrhBxI0VHV0CNcj06Cno3"
   } ],
   "limit" : 20,
   "next" : null,
   "offset" : 0,
   "previous" : null,
-  "total" : 3
+  "total" : 7
 }

--- a/user_test.go
+++ b/user_test.go
@@ -267,26 +267,35 @@ func TestCurrentUsersPlaylists(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if playlists.Limit != 20 {
-		t.Errorf("Expected limit 20, got %d\n", playlists.Limit)
+	if playlists.Limit != 5 {
+		t.Errorf("Expected limit 5, got %d\n", playlists.Limit)
 	}
-	if playlists.Total != 4 {
-		t.Errorf("Expected 4 playlists, got %d\n", playlists.Total)
+	if playlists.Offset != 20 {
+		t.Errorf("Expected offset 20, got %d\n", playlists.Offset)
 	}
+	if playlists.Total != 42 {
+		t.Errorf("Expected 42 playlists, got %d\n", playlists.Total)
+	}
+
 	tests := []struct {
-		Name       string
-		Public     bool
-		TrackCount uint
+		Name        string
+		Description string
+		Public      bool
+		TrackCount  uint
 	}{
-		{"Discover Weekly", false, 30},
-		{"Your Favorite Coffeehouse", false, 69},
-		{"Afternoon Acoustic", false, 99},
-		{"Yoga and Meditation", true, 31},
+		{"Core", "", true, 3},
+		{"Black/Atmo/Prog ?", "This is kinda fuzzy", true, 10},
+		{"Troll", "", false, 7},
+		{"Melomiel", "", true, 3},
+		{"HEAVY MIEL", "Deathcore,techdeath, tout ce qui tape plus fort que du melodeath", true, 10},
 	}
 	for i := range tests {
 		p := playlists.Playlists[i]
 		if p.Name != tests[i].Name {
 			t.Errorf("Expected '%s', got '%s'\n", tests[i].Name, p.Name)
+		}
+		if p.Description != tests[i].Description {
+			t.Errorf("Expected '%s', got '%s'\n", tests[i].Description, p.Description)
 		}
 		if p.IsPublic != tests[i].Public {
 			t.Errorf("Expected public to be %#v, got %#v\n", tests[i].Public, p.IsPublic)


### PR DESCRIPTION
For #200 

I updated  the `.txt` files in `test_data` related to the playlists, with the exception of `playlist_items_*.json`: 
They seem to be related to a deprecated or soon-to-be deprecated feature of the API (Which seems to have been replaced by the `/shows` endpoints.)