### PR TITLE
Add SaveShowsForCurrentUser endpoint

### DIFF
--- a/show.go
+++ b/show.go
@@ -209,8 +209,8 @@ func (c *Client) GetShowEpisodes(ctx context.Context, id string, opts ...Request
 
 // SaveShowsForCurrentUser saves one or more shows to current Spotify user's library.
 // API reference: https://developer.spotify.com/documentation/web-api/reference/#/operations/save-shows-user
-func (c *Client) SaveShowsForCurrentUser(ctx context.Context, ids []string) error {
-	spotifyURL := c.baseURL + "me/shows?ids=" + strings.Join(ids, ",")
+func (c *Client) SaveShowsForCurrentUser(ctx context.Context, ids []ID) error {
+	spotifyURL := c.baseURL + "me/shows?ids=" + strings.Join(toStringSlice(ids), ",")
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, spotifyURL, nil)
 	if err != nil {
 		return err

--- a/show.go
+++ b/show.go
@@ -2,6 +2,7 @@ package spotify
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -187,10 +188,10 @@ func (c *Client) GetShow(ctx context.Context, id ID, opts ...RequestOption) (*Fu
 	return &result, nil
 }
 
-// GetShowEpisodes retrieves paginated episode information about a specific show..
+// GetShowEpisodes retrieves paginated episode information about a specific show.
 // API reference: https://developer.spotify.com/documentation/web-api/reference/#endpoint-get-a-shows-episodes
 // Supported options: Market, Limit, Offset
-func (c *Client) GetShowEpisodes(ctx context.Context,  id string, opts ...RequestOption) (*SimpleEpisodePage, error) {
+func (c *Client) GetShowEpisodes(ctx context.Context, id string, opts ...RequestOption) (*SimpleEpisodePage, error) {
 	spotifyURL := c.baseURL + "shows/" + id + "/episodes"
 	if params := processOptions(opts...).urlParams.Encode(); params != "" {
 		spotifyURL += "?" + params
@@ -204,4 +205,16 @@ func (c *Client) GetShowEpisodes(ctx context.Context,  id string, opts ...Reques
 	}
 
 	return &result, nil
+}
+
+// SaveShowsForCurrentUser saves one or more shows to current Spotify user's library.
+// API reference: https://developer.spotify.com/documentation/web-api/reference/#/operations/save-shows-user
+func (c *Client) SaveShowsForCurrentUser(ctx context.Context, ids []string) error {
+	spotifyURL := c.baseURL + "me/shows?ids=" + strings.Join(ids, ",")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, spotifyURL, nil)
+	if err != nil {
+		return err
+	}
+
+	return c.execute(req, nil, http.StatusOK)
 }

--- a/show_test.go
+++ b/show_test.go
@@ -1,6 +1,7 @@
 package spotify
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"testing"
@@ -26,7 +27,7 @@ func TestGetShowEpisodes(t *testing.T) {
 	c, s := testClientFile(http.StatusOK, "test_data/get_show_episodes.txt")
 	defer s.Close()
 
-	r, err := c.GetShowEpisodes(context.Background(),"1234")
+	r, err := c.GetShowEpisodes(context.Background(), "1234")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,5 +39,29 @@ func TestGetShowEpisodes(t *testing.T) {
 	}
 	if len(r.Episodes) != 25 {
 		t.Error("Invalid data", len(r.Episodes))
+	}
+}
+
+func TestSaveShowsForCurrentUser(t *testing.T) {
+	c, s := testClient(http.StatusOK, new(bytes.Buffer), func(req *http.Request) {
+		if ids := req.URL.Query().Get("ids"); ids != "1,2" {
+			t.Error("Invalid data:", ids)
+		}
+	})
+	defer s.Close()
+
+	err := c.SaveShowsForCurrentUser(context.Background(), []string{"1", "2"})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSaveShowsForCurrentUser_Errors(t *testing.T) {
+	c, s := testClient(http.StatusInternalServerError, new(bytes.Buffer))
+	defer s.Close()
+
+	err := c.SaveShowsForCurrentUser(context.Background(), []string{"1"})
+	if err == nil {
+		t.Fatal(err)
 	}
 }

--- a/show_test.go
+++ b/show_test.go
@@ -50,7 +50,7 @@ func TestSaveShowsForCurrentUser(t *testing.T) {
 	})
 	defer s.Close()
 
-	err := c.SaveShowsForCurrentUser(context.Background(), []string{"1", "2"})
+	err := c.SaveShowsForCurrentUser(context.Background(), []ID{"1", "2"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +60,7 @@ func TestSaveShowsForCurrentUser_Errors(t *testing.T) {
 	c, s := testClient(http.StatusInternalServerError, new(bytes.Buffer))
 	defer s.Close()
 
-	err := c.SaveShowsForCurrentUser(context.Background(), []string{"1"})
+	err := c.SaveShowsForCurrentUser(context.Background(), []ID{"1"})
 	if err == nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR adds the SaveShowsForCurrentUser endpoint

https://developer.spotify.com/documentation/web-api/reference/#/operations/save-shows-user