### PR TITLE
Pass context to modifyLibrary calls

### DIFF
--- a/library.go
+++ b/library.go
@@ -75,7 +75,7 @@ func (c *Client) modifyLibrary(ctx context.Context, typ string, add bool, ids ..
 	if add {
 		method = "PUT"
 	}
-	req, err := http.NewRequest(method, spotifyURL, nil)
+	req, err := http.NewRequestWithContext(ctx, method, spotifyURL, nil)
 	if err != nil {
 		return err
 	}

--- a/library_test.go
+++ b/library_test.go
@@ -47,6 +47,19 @@ func TestAddTracksToLibraryFailure(t *testing.T) {
 	}
 }
 
+func TestAddTracksToLibraryWithContextCancelled(t *testing.T) {
+	client, server := testClientString(http.StatusOK, ``)
+	defer server.Close()
+
+	ctx, done := context.WithCancel(context.Background())
+	done()
+
+	err := client.AddTracksToLibrary(ctx, "4iV5W9uYEdYUVa79Axb7Rh", "1301WleyT98MSxVHPZCA6M")
+	if err == nil {
+		t.Error("Expected error and didn't get one")
+	}
+}
+
 func TestRemoveTracksFromLibrary(t *testing.T) {
 	client, server := testClientString(http.StatusOK, "")
 	defer server.Close()

--- a/library_test.go
+++ b/library_test.go
@@ -2,6 +2,7 @@ package spotify
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"testing"
 )
@@ -55,7 +56,7 @@ func TestAddTracksToLibraryWithContextCancelled(t *testing.T) {
 	done()
 
 	err := client.AddTracksToLibrary(ctx, "4iV5W9uYEdYUVa79Axb7Rh", "1301WleyT98MSxVHPZCA6M")
-	if err == nil {
+	if !errors.Is(err, context.Canceled) {
 		t.Error("Expected error and didn't get one")
 	}
 }

--- a/player.go
+++ b/player.go
@@ -387,7 +387,7 @@ func (c *Client) NextOpt(ctx context.Context, opt *PlayOptions) error {
 			spotifyURL += "?" + params
 		}
 	}
-	req, err := http.NewRequest(http.MethodPost, spotifyURL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, spotifyURL, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fix: use ctx in modifyLibrary calls