### PR TITLE
Allow retry period to be cancelled by context

### DIFF
--- a/spotify.go
+++ b/spotify.go
@@ -222,7 +222,7 @@ func (c *Client) execute(req *http.Request, result interface{}, needsStatus ...i
 				// If the context is cancelled, return the original error
 			case <-time.After(retryDuration(resp)):
 				continue
-      }
+                        }
 		}
 		if resp.StatusCode == http.StatusNoContent {
 			return nil

--- a/spotify.go
+++ b/spotify.go
@@ -215,8 +215,12 @@ func (c *Client) execute(req *http.Request, result interface{}, needsStatus ...i
 		defer resp.Body.Close()
 
 		if c.autoRetry && shouldRetry(resp.StatusCode) {
-			time.Sleep(retryDuration(resp))
-			continue
+			select {
+			case <-req.Context().Done():
+				// If the context is cancelled, return the original error
+			case <-time.After(retryDuration(resp)):
+				continue
+			}
 		}
 		if resp.StatusCode == http.StatusNoContent {
 			return nil
@@ -266,8 +270,12 @@ func (c *Client) get(ctx context.Context, url string, result interface{}) error 
 		defer resp.Body.Close()
 
 		if resp.StatusCode == rateLimitExceededStatusCode && c.autoRetry {
-			time.Sleep(retryDuration(resp))
-			continue
+			select {
+			case <-ctx.Done():
+				// If the context is cancelled, return the original error
+			case <-time.After(retryDuration(resp)):
+				continue
+			}
 		}
 		if resp.StatusCode == http.StatusNoContent {
 			return nil


### PR DESCRIPTION
Currently, given the use of `time.Sleep`, retry time periods completely ignore the context passed into the function. This PR swaps the sleep logic to instead use a `select` and `time.After`, so that context cancellation will successfully cancel the sleep. The behavior in this PR is just to return the original error if context is cancelled during the retry Sleep. If you'd prefer, I can also swap to return a context cancellation, too.
Signed-off-by: Russell Troxel <russelltroxel@gmail.com>