### PR TITLE
[Fix #182] Test success before retrying request

### DIFF
--- a/spotify.go
+++ b/spotify.go
@@ -214,7 +214,9 @@ func (c *Client) execute(req *http.Request, result interface{}, needsStatus ...i
 		}
 		defer resp.Body.Close()
 
-		if c.autoRetry && shouldRetry(resp.StatusCode) {
+		if c.autoRetry &&
+			isFailure(resp.StatusCode, needsStatus) &&
+			shouldRetry(resp.StatusCode) {
 			time.Sleep(retryDuration(resp))
 			continue
 		}


### PR DESCRIPTION
Fixes #182 

In #183 concern was raised that removing `202` responses from `shouldRetry` might lead to breakage elsewhere. This PR takes a slightly different approach, and instead just checking `isFailure` to determine if we have the status we're looking for before deciding if we should retry the request.

Signed-off-by: Russell Troxel <russelltroxel@gmail.com>