### PR TITLE
Make spotify.PlaybackOffset.Position an *int 

### DIFF
--- a/player.go
+++ b/player.go
@@ -84,7 +84,7 @@ type RecentlyPlayedResult struct {
 // the request may be accepted but with an unpredictable resulting action on playback.
 type PlaybackOffset struct {
 	// Position is zero based and can’t be negative.
-	Position int `json:"position"`
+	Position *int `json:"position,omitempty"`
 	// URI is a string representing the uri of the item to start at.
 	URI URI `json:"uri,omitempty"`
 }

--- a/player.go
+++ b/player.go
@@ -79,9 +79,13 @@ type RecentlyPlayedResult struct {
 	Items []RecentlyPlayedItem `json:"items"`
 }
 
-// PlaybackOffset can be specified either by track URI OR Position. If both are present the
-// request will return 400 BAD REQUEST. If incorrect values are provided for position or uri,
-// the request may be accepted but with an unpredictable resulting action on playback.
+// PlaybackOffset can be specified either by track URI OR Position. If the
+// Position field is set to a non-nil pointer, it will be taken into
+// consideration when specifying the playback offset. If the Position field is
+// set to a nil pointer, it will be ignored and only the URI will be used to
+// specify the offset. If both are present the request will return 400 BAD
+// REQUEST. If incorrect values are provided for position or uri, the request
+// may be accepted but with an unpredictable resulting action on playback.
 type PlaybackOffset struct {
 	// Position is zero based and can’t be negative.
 	Position *int `json:"position,omitempty"`


### PR DESCRIPTION
Fixes #219 

https://github.com/zmb3/spotify/commit/9d29507c9a13689c913905f76e69974e8b234072 changed the JSON tag of the PlaybackOffset.Position resulting in it not being ignored when only URI was set. Which lead to the error mentioned #219. This PR fixes this by making PlaybackOffset.Position an integer pointer, hence it won't be ignored when it will be zero and will be ignored when only URI is set.