### PR TITLE
func (a Authenticator) Token() more portable

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/url"
 	"os"
 
 	"golang.org/x/oauth2"
@@ -152,11 +153,11 @@ func (a Authenticator) AuthURL(state string, opts ...oauth2.AuthCodeOption) stri
 	return a.config.AuthCodeURL(state, opts...)
 }
 
-// Token pulls an authorization code from an HTTP request and attempts to exchange
+// Token pulls an authorization code from a redirected URL and attempts to exchange
 // it for an access token.  The standard use case is to call Token from the handler
 // that handles requests to your application's redirect URL.
-func (a Authenticator) Token(ctx context.Context, state string, r *http.Request, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
-	values := r.URL.Query()
+func (a Authenticator) Token(ctx context.Context, state string, redirect *url.URL, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {
+	values := redirect.Query()
 	if e := values.Get("error"); e != "" {
 		return nil, errors.New("spotify: auth failed - " + e)
 	}

--- a/examples/authenticate/authcode/authenticate.go
+++ b/examples/authenticate/authcode/authenticate.go
@@ -56,7 +56,7 @@ func main() {
 }
 
 func completeAuth(w http.ResponseWriter, r *http.Request) {
-	tok, err := auth.Token(r.Context(), state, r)
+	tok, err := auth.Token(r.Context(), state, r.URL)
 	if err != nil {
 		http.Error(w, "Couldn't get token", http.StatusForbidden)
 		log.Fatal(err)

--- a/examples/authenticate/pkce/pkce.go
+++ b/examples/authenticate/pkce/pkce.go
@@ -60,7 +60,7 @@ func main() {
 }
 
 func completeAuth(w http.ResponseWriter, r *http.Request) {
-	tok, err := auth.Token(r.Context(), state, r,
+	tok, err := auth.Token(r.Context(), state, r.URL,
 		oauth2.SetAuthURLParam("code_verifier", codeVerifier))
 	if err != nil {
 		http.Error(w, "Couldn't get token", http.StatusForbidden)

--- a/examples/player/player.go
+++ b/examples/player/player.go
@@ -105,7 +105,7 @@ func main() {
 }
 
 func completeAuth(w http.ResponseWriter, r *http.Request) {
-	tok, err := auth.Token(r.Context(), state, r)
+	tok, err := auth.Token(r.Context(), state, r.URL)
 	if err != nil {
 		http.Error(w, "Couldn't get token", http.StatusForbidden)
 		log.Fatal(err)


### PR DESCRIPTION
Hi!  I appreciate all the work that's gone into this pkg, and this PR helps make it more a little more reusable.

This PR makes `func (a Authenticator) Token()` now takes the redirected URL rather than a `http.Request` (which assumes Go was used as a server to receive the redirect and makes less sense to pass in).  

It's either this or also add a `http.Request` variant of `func (a Authenticator) Token()` to other calls to have to be changed, but I think it makes more sense to take in the URL than the reader.

