### PR TITLE
add RefreshToken method for Authenticator

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -171,8 +171,8 @@ func (a Authenticator) Token(ctx context.Context, state string, r *http.Request,
 	return a.config.Exchange(ctx, code, opts...)
 }
 
-// Return a new access token if it has expired.
-// If it has not expired, return the existing access token.
+// Return a new token if an access token has expired.
+// If it has not expired, return the existing token.
 func (a Authenticator) RefreshToken(ctx context.Context, token *oauth2.Token) (*oauth2.Token, error) {
 	src := a.config.TokenSource(ctx, token)
 	return src.Token()

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -171,6 +171,13 @@ func (a Authenticator) Token(ctx context.Context, state string, r *http.Request,
 	return a.config.Exchange(ctx, code, opts...)
 }
 
+// Return a new access token if it has expired.
+// If it has not expired, return the existing access token.
+func (a Authenticator) RefreshToken(ctx context.Context, token *oauth2.Token) (*oauth2.Token, error) {
+	src := a.config.TokenSource(ctx, token)
+	return src.Token()
+}
+
 // Exchange is like Token, except it allows you to manually specify the access
 // code instead of pulling it out of an HTTP request.
 func (a Authenticator) Exchange(ctx context.Context, code string, opts ...oauth2.AuthCodeOption) (*oauth2.Token, error) {


### PR DESCRIPTION
## Overview
Existing code did not have a mechanism to update access tokens with refresh tokens.
So I added `RefreshToken` method which returns a new access token if it has expired.

## Example of use
```go
ctx := context.Background()
token := getToken() // get an existing token somehow
auth := spotifyauth.New()
newToken, err := auth.RefreshToken(ctx, token) // refresh token here
if err != nil {
  fmt.Println(err)
}
if token.AccessToken != newToken.AccessToken {
  saveToken(newToken) // save a new token
}
client := spotify.New(auth.Client(ctx, newToken))
```


## Related 
- #232 
- #221 