### PR TITLE
fix: add client_id field to pkce auth example.

### DIFF
--- a/examples/authenticate/pkce/pkce.go
+++ b/examples/authenticate/pkce/pkce.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	spotifyauth "github.com/zmb3/spotify/v2/auth"
 	"log"
+	"os"
 	"net/http"
 
 	"golang.org/x/oauth2"
@@ -45,6 +46,7 @@ func main() {
 	url := auth.AuthURL(state,
 		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
 		oauth2.SetAuthURLParam("code_challenge", codeChallenge),
+		oauth2.SetAuthURLParam("client_id", os.Getenv("CLIENT_ID")),
 	)
 	fmt.Println("Please log in to Spotify by visiting the following page in your browser:", url)
 


### PR DESCRIPTION
Simple fix for pkce auth example that I stumbled across while trying the library. I'm unsure if this is a a specification requirement for pkce auth as I haven't finished reading the RFC, but if you do not set the client_id as a param, you get a helpful message that it needs to be set. 

This change assumes that the user will provide the client_id as an env var. 