### PR TITLE
Remove duplicate Album and ExternalIDs fields from FullTrack

### DIFF
--- a/track.go
+++ b/track.go
@@ -73,10 +73,6 @@ type LinkedFromInfo struct {
 // FullTrack provides extra track data in addition to what is provided by SimpleTrack.
 type FullTrack struct {
 	SimpleTrack
-	// The album on which the track appears. The album object includes a link in href to full information about the album.
-	Album SimpleAlbum `json:"album"`
-	// Known external IDs for the track.
-	ExternalIDs map[string]string `json:"external_ids"`
 	// Popularity of the track.  The value will be between 0 and 100,
 	// with 100 being the most popular.  The popularity is calculated from
 	// both total plays and most recent plays.

--- a/user_test.go
+++ b/user_test.go
@@ -447,10 +447,7 @@ func TestCurrentUsersTopTracks(t *testing.T) {
 	}
 
 	isrc := "QZ4JJ1764466"
-	i, ok := tracks.Tracks[0].ExternalIDs["isrc"]
-	if !ok {
-		t.Error("External IDs missing ISRC")
-	}
+	i := tracks.Tracks[0].ExternalIDs.ISRC
 	if i != isrc {
 		t.Errorf("Wrong ISRC: want %s, got %s\n", isrc, i)
 	}


### PR DESCRIPTION
They're both already present in SimpleTrack, and in the case of ExternalIDs, in a more convenient form.  By putting the duplicate in FullTrack, SimpleTrack is rendered invalid/incomplete (since the json tags on the embedded fields are shadowed), and also use a less useful type (map[string]string, rather than TrackExternalIDs).


This is, of course, a breaking change, and should target v3.