### PR TITLE
Remove the Version constant

### DIFF
--- a/spotify.go
+++ b/spotify.go
@@ -17,9 +17,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// Version is the version of this library.
-const Version = "1.0.0"
-
 const (
 	// DateLayout can be used with time.Parse to create time.Time values
 	// from Spotify date strings.  For example, PrivateUser.Birthdate


### PR DESCRIPTION
~It may be a better idea simply to remove this constant, as it's not referenced anywhere internally, and clearly hasn't been updated in long time, so it seems unlikely anybody is using it for anything valuable.  And v3 is a nice time to remove unused things.~

Remove woefully outdated Version constant