### PR TITLE
Properly decode 429 error responses

### DIFF
--- a/category_test.go
+++ b/category_test.go
@@ -3,7 +3,6 @@ package spotify
 import (
 	"context"
 	"net/http"
-	"strings"
 	"testing"
 )
 
@@ -93,8 +92,8 @@ func TestGetCategoryPlaylistsOpt(t *testing.T) {
 	defer server.Close()
 
 	_, err := client.GetCategoryPlaylists(context.Background(), "id", Limit(5), Offset(10))
-	if err == nil || !strings.Contains(err.Error(), "HTTP 404: Not Found") {
-		t.Errorf("Expected error 'spotify: HTTP 404: Not Found (body empty)', got %v", err)
+	if want := "Not Found"; err == nil || err.Error() != want {
+		t.Errorf("Expected error: want %v, got %v", want, err)
 	}
 }
 

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 )
@@ -606,7 +605,7 @@ func TestClient_ReplacePlaylistItems(t *testing.T) {
 				items:      []URI{"spotify:track:track1", "spotify:track:track2"},
 			},
 			want: want{
-				err: "spotify: HTTP 403: Forbidden (body empty)",
+				err: "Forbidden",
 			},
 		},
 	}
@@ -714,8 +713,8 @@ func TestReorderPlaylistRequest(t *testing.T) {
 		RangeStart:   3,
 		InsertBefore: 8,
 	})
-	if err == nil || !strings.Contains(err.Error(), "HTTP 404: Not Found") {
-		t.Errorf("Expected error 'spotify: HTTP 404: Not Found (body empty)', got %v", err)
+	if want := "Not Found"; err == nil || err.Error() != want {
+		t.Errorf("Expected error: want %v, got %v", want, err)
 	}
 }
 

--- a/spotify_test.go
+++ b/spotify_test.go
@@ -2,7 +2,6 @@ package spotify
 
 import (
 	"context"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/oauth2"
 )
 
 func testClient(code int, body io.Reader, validators ...func(*http.Request)) (*Client, *httptest.Server) {
@@ -70,7 +71,7 @@ func TestNewReleasesRateLimitExceeded(t *testing.T) {
 		// first attempt fails
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Retry-After", "2")
-			w.WriteHeader(rateLimitExceededStatusCode)
+			w.WriteHeader(http.StatusTooManyRequests)
 			_, _ = io.WriteString(w, `{ "error": { "message": "slow down", "status": 429 } }`)
 		}),
 		// next attempt succeeds
@@ -144,14 +145,14 @@ func TestClient_Token(t *testing.T) {
 
 	t.Run("non oauth2 transport", func(t *testing.T) {
 		client := &Client{
-			http:    http.DefaultClient,
+			http: http.DefaultClient,
 		}
 		_, err := client.Token()
 		if err == nil || err.Error() != "spotify: client not backed by oauth2 transport" {
 			t.Errorf("Should throw error: %s", "spotify: client not backed by oauth2 transport")
 		}
 	})
-	
+
 	t.Run("invalid token", func(t *testing.T) {
 		httpClient := config.Client(context.Background(), nil)
 		client := New(httpClient)
@@ -160,4 +161,20 @@ func TestClient_Token(t *testing.T) {
 			t.Errorf("Should throw error: %s", "oauth2: token expired and refresh token is not set")
 		}
 	})
+}
+
+func TestDecode429Error(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{"Retry-After": []string{"2"}},
+		Body:       io.NopCloser(strings.NewReader(`Too many requests`)),
+	}
+
+	err := decodeError(resp)
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+	if err.Error() != "Too many requests" {
+		t.Error("Invalid error message:", err.Error())
+	}
 }

--- a/user_test.go
+++ b/user_test.go
@@ -129,7 +129,7 @@ func TestFollowArtistAutoRetry(t *testing.T) {
 		// first attempt fails
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Retry-After", "2")
-			w.WriteHeader(rateLimitExceededStatusCode)
+			w.WriteHeader(http.StatusTooManyRequests)
 			_, _ = io.WriteString(w, `{ "error": { "message": "slow down", "status": 429 } }`)
 		}),
 		// next attempt succeeds


### PR DESCRIPTION
As well as any other error responses that are not of content-type application/json