### PR TITLE
More consistently include the HTTP response code in errors

### DIFF
--- a/category_test.go
+++ b/category_test.go
@@ -92,7 +92,7 @@ func TestGetCategoryPlaylistsOpt(t *testing.T) {
 	defer server.Close()
 
 	_, err := client.GetCategoryPlaylists(context.Background(), "id", Limit(5), Offset(10))
-	if want := "Not Found"; err == nil || err.Error() != want {
+	if want := "spotify: Not Found [404]"; err == nil || err.Error() != want {
 		t.Errorf("Expected error: want %v, got %v", want, err)
 	}
 }

--- a/playlist_test.go
+++ b/playlist_test.go
@@ -605,7 +605,7 @@ func TestClient_ReplacePlaylistItems(t *testing.T) {
 				items:      []URI{"spotify:track:track1", "spotify:track:track2"},
 			},
 			want: want{
-				err: "Forbidden",
+				err: "spotify: Forbidden [403]",
 			},
 		},
 	}
@@ -713,7 +713,7 @@ func TestReorderPlaylistRequest(t *testing.T) {
 		RangeStart:   3,
 		InsertBefore: 8,
 	})
-	if want := "Not Found"; err == nil || err.Error() != want {
+	if want := "spotify: Not Found [404]"; err == nil || err.Error() != want {
 		t.Errorf("Expected error: want %v, got %v", want, err)
 	}
 }

--- a/spotify_test.go
+++ b/spotify_test.go
@@ -115,7 +115,7 @@ func TestRateLimitExceededReportsRetryAfter(t *testing.T) {
 		// first attempt fails
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
-			w.WriteHeader(rateLimitExceededStatusCode)
+			w.WriteHeader(http.StatusTooManyRequests)
 			_, _ = io.WriteString(w, `{ "error": { "message": "slow down", "status": 429 } }`)
 		}),
 		// next attempt succeeds

--- a/spotify_test.go
+++ b/spotify_test.go
@@ -222,7 +222,7 @@ func TestDecode429Error(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error")
 	}
-	if err.Error() != "Too many requests" {
-		t.Error("Invalid error message:", err.Error())
+	if err.Error() != "spotify: Too many requests [429]" {
+		t.Error("Unexpected error message:", err.Error())
 	}
 }

--- a/spotify_test.go
+++ b/spotify_test.go
@@ -225,4 +225,13 @@ func TestDecode429Error(t *testing.T) {
 	if err.Error() != "spotify: Too many requests [429]" {
 		t.Error("Unexpected error message:", err.Error())
 	}
+	const wantSTatus = http.StatusTooManyRequests
+	var gotStatus int
+	var statusErr interface{ HTTPStatus() int }
+	if errors.As(err, &statusErr) {
+		gotStatus = statusErr.HTTPStatus()
+	}
+	if gotStatus != wantSTatus {
+		t.Errorf("Expected status %d, got %d", wantSTatus, gotStatus)
+	}
 }


### PR DESCRIPTION
Today's Spotify outage, and the plethora of random errors it's causing my service to return, inspired me to make errors a bit more parseable.

This PR does two things:

- It adds a convenience `HTTPStatus() int` method on the custom `spotify.Error` type, as an easy way to convient the HTTP status.
- It ensures that all errors actually include said HTTP status, when it's available.

It also changes the wording of some errors, for consistency, which may break some consumers of this library, if they depend on error string matching, which this PR will help make less necessary.